### PR TITLE
Add debug marking to register service logs

### DIFF
--- a/packages/cli-zendesk/package.json
+++ b/packages/cli-zendesk/package.json
@@ -21,8 +21,8 @@
     "yup": "^0.27.0"
   },
   "scripts": {
-    "start:user": "node --inspect dist/index.js -m user",
-    "start:ticket": "node --inspect dist/index.js -m ticket",
+    "start:user": "DEBUG=cli-zendesk* node --inspect dist/index.js -m user",
+    "start:ticket": "DEBUG=cli-zendesk* node --inspect dist/index.js -m ticket",
     "dev:user": "DEBUG=cli-zendesk* tsc-watch --onSuccess \"node --inspect dist/index.js -m user\"",
     "dev:ticket": "DEBUG=cli-zendesk* tsc-watch --onSuccess \"node --inspect dist/index.js -m ticket\"",
     "dev:help": "DEBUG=cli-zendesk* tsc-watch --onSuccess \"node --inspect dist/index.js --help\"",

--- a/packages/webhooks-mautic-zendesk/package.json
+++ b/packages/webhooks-mautic-zendesk/package.json
@@ -11,7 +11,7 @@
     "yup": "^0.27.0"
   },
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "DEBUG=webhooks-mautic-zendesk* node dist/index.js",
     "dev": "DEBUG=webhooks-mautic-zendesk* tsc-watch --onSuccess \"node dist/index.js\"",
     "clean": "rm -rf node_modules dist",
     "build": "tsc"

--- a/packages/webhooks-solidarity-count/src/App.ts
+++ b/packages/webhooks-solidarity-count/src/App.ts
@@ -182,11 +182,10 @@ const App = async (ticket_id: string, res: Response) => {
     return res.status(200).json("Ok!");
   }
 
-  log(
-    `Internal server error relative to organization parse, ticket '${ticket_id}'.`
-  );
   log("Finished sync");
-  return res.status(500).json("Failed to parse this organization_id");
+  return res
+    .status(202)
+    .json(`Failed to parse the organization_id for this ticket '${ticket_id}`);
 };
 
 export default App;


### PR DESCRIPTION
Also fixes issue with solidarity_count where the server was responding with a 500 status when the ticket didnt had any organization_id. Zendesk was complaining about the constant 500 error status, so the res status now is 202. 