### PR TITLE
Passing correct ticket_id when forwarding to public service

### DIFF
--- a/packages/listener-match/__tests__/handleTicket.spec.ts
+++ b/packages/listener-match/__tests__/handleTicket.spec.ts
@@ -15,6 +15,19 @@ describe("Handle Ticket", () => {
     expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22964);
   });
 
+  it("should pass if 'solicitação_repetida' and field 'atrelado_ao_ticket' is not null", async () => {
+    const ticket = {
+      subject: "[Psicológico] teste nova msr, São Paulo - SP",
+      ticket_id: 22970,
+      atrelado_ao_ticket: 22965,
+      requester_id: 0,
+      nome_msr: "teste nova msr",
+      status_acolhimento: "solicitação_repetida",
+      external_id: 0
+    };
+    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22970);
+  });
+
   it("should return early if ticket subject doesn't have a subject with a type", async () => {
     const ticket = {
       subject: "Re: Temos um recado para você!",
@@ -27,5 +40,18 @@ describe("Handle Ticket", () => {
       __typename: "solidarity_tickets"
     };
     expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22964);
+  });
+
+  it("should pass because subject is correct", async () => {
+    const ticket = {
+      subject: "[Jurídico] Viviane, Imbituba - SC",
+      ticket_id: 27072,
+      atrelado_ao_ticket: null,
+      requester_id: 0,
+      nome_msr: "Viviane",
+      status_acolhimento: "solicitação_recebida",
+      external_id: 0
+    };
+    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(27072);
   });
 });

--- a/packages/listener-match/__tests__/utils.spec.ts
+++ b/packages/listener-match/__tests__/utils.spec.ts
@@ -11,7 +11,7 @@ import {
 
 describe("Utils", () => {
   it('should return "therapist" if support type is "psicológico"', () => {
-    const subject = "[Psicológico] Teste, Rio de Janeiro  - RJ";
+    const subject = "[Psicológico] Lilian, Paranapanema - SP";
     expect(getRequestedVolunteerType(subject)).toStrictEqual("therapist");
   });
   it('should return "lawyer" if support type is "jurídico"', () => {

--- a/packages/listener-match/src/components/Services/handleTicket.ts
+++ b/packages/listener-match/src/components/Services/handleTicket.ts
@@ -68,13 +68,15 @@ export default async (
   if (!volunteer) {
     const updateIndividual = await forwardPublicService(
       {
-        ticket_id: ticketId,
+        ticket_id: localIndividualTicket["ticket_id"],
         state: individual[0].state
       },
       AGENT
     );
     if (!updateIndividual) return undefined;
-    return ticketId;
+    return localIndividualTicket["ticket_id"] !== individualTicket["ticket_id"]
+      ? [individualTicket["ticket_id"], updateIndividual]
+      : updateIndividual;
   }
 
   const volunteerTicketId = await createVolunteerTicket(


### PR DESCRIPTION
Pass localIndividualTicket ticket_id when forwarding to public service

When adding the localIndividualTicket const, the ticket_id variable passed to the forwardPublicService() function wasn't changed.
This probably led to tickets with status_acolhimento = solicitação_repetida receiving matchs (they shouldnt).

Adds more logs to understand if script suddenly returns before the expected moment.