### PR TITLE
Fetch individual ticket info at subscription

### DIFF
--- a/packages/listener-match/__tests__/handleTicket.spec.ts
+++ b/packages/listener-match/__tests__/handleTicket.spec.ts
@@ -10,7 +10,12 @@ describe("Handle Ticket", () => {
       nome_msr: "teste nova msr",
       status_acolhimento: "solicitação_repetida",
       external_id: 2000362,
-      __typename: "solidarity_tickets"
+      __typename: "solidarity_tickets",
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SP"
+      }
     };
     expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22964);
   });
@@ -23,9 +28,14 @@ describe("Handle Ticket", () => {
       requester_id: 0,
       nome_msr: "teste nova msr",
       status_acolhimento: "solicitação_repetida",
-      external_id: 0
+      external_id: 0,
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SP"
+      }
     };
-    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22970);
+    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(undefined);
   });
 
   it("should return early if ticket subject doesn't have a subject with a type", async () => {
@@ -37,7 +47,12 @@ describe("Handle Ticket", () => {
       nome_msr: "teste nova msr",
       status_acolhimento: "solicitação_recebida",
       external_id: 2000362,
-      __typename: "solidarity_tickets"
+      __typename: "solidarity_tickets",
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SP"
+      }
     };
     expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(22964);
   });
@@ -50,8 +65,13 @@ describe("Handle Ticket", () => {
       requester_id: 0,
       nome_msr: "Viviane",
       status_acolhimento: "solicitação_recebida",
-      external_id: 0
+      external_id: 0,
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SC"
+      }
     };
-    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(27072);
+    expect(await handleTicket(ticket, [] as never, 1)).toStrictEqual(undefined);
   });
 });

--- a/packages/listener-match/__tests__/queue.spec.ts
+++ b/packages/listener-match/__tests__/queue.spec.ts
@@ -12,7 +12,12 @@ describe("Test queue operations", () => {
       nome_msr: "Viviane",
       status_acolhimento: "solicitação_recebida",
       external_id: 2000362,
-      __typename: "solidarity_tickets"
+      __typename: "solidarity_tickets",
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SP"
+      }
     },
     {
       subject: "[Jurídico] Viviane, Taubaté - SP",
@@ -22,7 +27,12 @@ describe("Test queue operations", () => {
       nome_msr: "Viviane",
       status_acolhimento: "solicitação_recebida",
       external_id: 2000362,
-      __typename: "solidarity_tickets"
+      __typename: "solidarity_tickets",
+      individual: {
+        latitude: "0",
+        longitude: "0",
+        state: "SP"
+      }
     }
   ];
 

--- a/packages/listener-match/__tests__/setRecursionLogic.spec.ts
+++ b/packages/listener-match/__tests__/setRecursionLogic.spec.ts
@@ -18,7 +18,12 @@ describe("Test handleMatch recursion logic", () => {
         nome_msr: "Viviane",
         status_acolhimento: "solicitação_recebida",
         external_id: 2000362,
-        __typename: "solidarity_tickets"
+        __typename: "solidarity_tickets",
+        individual: {
+          latitude: "0",
+          longitude: "0",
+          state: "SP"
+        }
       },
       {
         subject: "[Jurídico] Viviane, Taubaté - SP",
@@ -28,7 +33,12 @@ describe("Test handleMatch recursion logic", () => {
         nome_msr: "Viviane",
         status_acolhimento: "solicitação_recebida",
         external_id: 2000362,
-        __typename: "solidarity_tickets"
+        __typename: "solidarity_tickets",
+        individual: {
+          latitude: "0",
+          longitude: "0",
+          state: "SP"
+        }
       }
     ];
     const recursion = setRecursionLogic(tickets);

--- a/packages/listener-match/src/components/Services/handleTicket.ts
+++ b/packages/listener-match/src/components/Services/handleTicket.ts
@@ -1,9 +1,5 @@
 import { getClosestVolunteer, createVolunteerTicket } from "../Volunteers";
-import {
-  fetchIndividual,
-  forwardPublicService,
-  updateIndividualTicket
-} from "../Individual";
+import { forwardPublicService, updateIndividualTicket } from "../Individual";
 import { createMatchTicket } from "../../graphql/mutations";
 import { Volunteer, IndividualTicket } from "../../types";
 import {
@@ -37,7 +33,8 @@ export default async (
     status_acolhimento: statusAcolhimento,
     atrelado_ao_ticket: atreladoAoTicket,
     requester_id: requesterId,
-    ticket_id: ticketId
+    ticket_id: ticketId,
+    individual
   } = individualTicket;
 
   if (
@@ -62,19 +59,13 @@ export default async (
     ({ organization_id }) => organization_id === volunteerOrganizationId
   );
 
-  const individual = await fetchIndividual(requesterId);
-  if (typeof individual === "undefined" || individual.length < 1) {
-    log(`No individual was found with this requester_id '${requesterId}'`);
-    return ticketId;
-  }
-
   log(`Searching for closest volunteer to MSR '${requesterId}'`);
-  const volunteer = getClosestVolunteer(individual[0], filteredVolunteers);
+  const volunteer = getClosestVolunteer(individual, filteredVolunteers);
   if (!volunteer) {
     const updateIndividual = await forwardPublicService(
       {
         ticket_id: localIndividualTicket["ticket_id"],
-        state: individual[0].state
+        state: individual.state
       },
       AGENT
     );

--- a/packages/listener-match/src/graphql/subscriptions/fetchSolidarityTickets.ts
+++ b/packages/listener-match/src/graphql/subscriptions/fetchSolidarityTickets.ts
@@ -9,7 +9,12 @@ const SOLIDARITY_USERS_SUBSCRIPTION = gql`
   subscription pipeline_solidarity_tickets($organization_id: bigint) {
     solidarity_tickets(
       where: {
-        organization_id: { _eq: $organization_id }
+        individual: {
+          organization_id: { _eq: $organization_id }
+          latitude: { _is_null: false }
+          longitude: { _is_null: false }
+          state: { _is_null: false }
+        }
         _or: [
           { status_acolhimento: { _eq: "solicitação_repetida" } }
           { status_acolhimento: { _eq: "solicitação_recebida" } }
@@ -24,6 +29,11 @@ const SOLIDARITY_USERS_SUBSCRIPTION = gql`
       }
       order_by: { data_inscricao_bonde: asc }
     ) {
+      individual {
+        latitude
+        longitude
+        state
+      }
       subject
       ticket_id
       atrelado_ao_ticket

--- a/packages/listener-match/src/types/index.ts
+++ b/packages/listener-match/src/types/index.ts
@@ -6,6 +6,7 @@ export type IndividualTicket = {
   nome_msr: string;
   status_acolhimento: string;
   external_id: number;
+  individual: Individual;
 };
 
 export type SubscriptionResponse = {
@@ -29,18 +30,17 @@ export type Volunteer = {
   ticket_id?: number;
 };
 
-export type MatchTickets = {
-  volunteers_user_id: number;
-  volunteers_ticket_id: number;
-  id: number;
-};
-
 export type Individual = {
   latitude: string;
   longitude: string;
   state: string;
 };
 
+export type MatchTickets = {
+  volunteers_user_id: number;
+  volunteers_ticket_id: number;
+  id: number;
+};
 export type Ticket = {
   id?: number;
   requester_id: number;


### PR DESCRIPTION
There was an error occurring when fetching the individual data in `handleTicket`. 

This was probably due to a delay when saving the individual in listener-solidarity. Thus when it entered listener-match and the function `handleTicket` made a req to `solidarity_users` asking for the user data, it wasn't saved.

To solve this issue we don't fetch the individual data in `handleTicket` via the `fetchIndividual` function anymore. Because a relationship between `solidarity_tickets` and `solidarity_users` was created, I can get the data from the user related to the ticket right at the subscription query.

This avoids possible individuals without valuable data for the match to occur.