### PR TITLE
Refactoring mautic zendesk

### DIFF
--- a/packages/webhooks-mautic-zendesk/jest.config.js
+++ b/packages/webhooks-mautic-zendesk/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(ts|js)x?$",
   coverageDirectory: "coverage",
   collectCoverageFrom: ["src/**/*.{ts,tsx,js,jsx}", "!src/**/*.d.ts"],
+  setupFiles: ["<rootDir>/src/beforeEachTest.ts"],
   modulePathIgnorePatterns: ["dist/"],
   preset: "ts-jest",
   globals: {

--- a/packages/webhooks-mautic-zendesk/package.json
+++ b/packages/webhooks-mautic-zendesk/package.json
@@ -18,7 +18,8 @@
     "dev": "DEBUG=webhooks-mautic-zendesk* tsc-watch --onSuccess \"node dist/index.js\"",
     "clean": "rm -rf node_modules dist",
     "build": "tsc -p tsconfig.json",
-    "test": "jest --coverage --passWithNoTests"
+    "test": "jest --coverage",
+    "test:watch": "jest --watch --runInBand --detectOpenHandles"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/webhooks-mautic-zendesk/src/Server.ts
+++ b/packages/webhooks-mautic-zendesk/src/Server.ts
@@ -12,6 +12,7 @@ import { FILTER_SERVICE_STATUS, filterService } from "./filterService";
 import { FILTER_FORM_NAME_STATUS, filterFormName } from "./filterFormName";
 import BondeCreatedDate from "./integrations/BondeCreatedDate";
 import addTagsToTicket from "./zendesk/addTagsToTicket";
+import { checkNames, checkCep } from "./utils";
 
 // interface DataType {
 //   data: {
@@ -213,40 +214,6 @@ class Server {
     });
   };
 
-  checkNames = ({
-    primeiro_nome,
-    sobrenome_completo
-  }: {
-    primeiro_nome;
-    sobrenome_completo;
-  }) => {
-    let aux = "";
-    if (typeof primeiro_nome === "string" && primeiro_nome.length > 0) {
-      aux += primeiro_nome;
-    }
-
-    if (
-      typeof sobrenome_completo === "string" &&
-      sobrenome_completo.length > 0
-    ) {
-      aux += ` ${sobrenome_completo}`;
-    }
-
-    if (aux.length > 0) {
-      return aux;
-    }
-
-    return null;
-  };
-
-  checkCep = (cep: string) => {
-    if (typeof cep === "string" && cep.length > 0) {
-      return cep;
-    }
-
-    return null;
-  };
-
   start = () => {
     const { PORT } = process.env;
     this.server
@@ -298,8 +265,8 @@ class Server {
         }
         const bondeCreatedDate = new BondeCreatedDate(
           results.email,
-          this.checkNames(results),
-          this.checkCep(results.cep)
+          checkNames(results),
+          checkCep(results.cep)
         );
         const bondeCreatedAt = await bondeCreatedDate.start();
 

--- a/packages/webhooks-mautic-zendesk/src/Server.ts
+++ b/packages/webhooks-mautic-zendesk/src/Server.ts
@@ -290,7 +290,7 @@ class Server {
         }
 
         if (!user.response) {
-          this.dbg("Failed to create user");
+          this.dbg(`Failed to create user ${results.email}`);
           return res.status(500).json("Failed to create user");
         }
 

--- a/packages/webhooks-mautic-zendesk/src/Server.ts
+++ b/packages/webhooks-mautic-zendesk/src/Server.ts
@@ -10,6 +10,7 @@ import PsicologaCreateTicket from "./integrations/PsicologaCreateTicket";
 import PsicologaUpdateTicket from "./integrations/PsicologaUpdateTicket";
 import { FILTER_SERVICE_STATUS, filterService } from "./filterService";
 import { FILTER_FORM_NAME_STATUS, filterFormName } from "./filterFormName";
+import getFormEntries from "./getFormEntries";
 import BondeCreatedDate from "./integrations/BondeCreatedDate";
 import addTagsToTicket from "./zendesk/addTagsToTicket";
 import { checkNames, checkCep } from "./utils";
@@ -263,12 +264,18 @@ class Server {
             .status(400)
             .json("Invalid request, failed to parse results");
         }
+
+        const formEntries = await getFormEntries();
+        if (!formEntries) {
+          return this.dbg("getFormEntries error");
+        }
+
         const bondeCreatedDate = new BondeCreatedDate(
           results.email,
           checkNames(results),
           checkCep(results.cep)
         );
-        const bondeCreatedAt = await bondeCreatedDate.start();
+        const bondeCreatedAt = await bondeCreatedDate.start(formEntries);
 
         if (!bondeCreatedAt) {
           return this.dbg(bondeCreatedAt);

--- a/packages/webhooks-mautic-zendesk/src/Server.ts
+++ b/packages/webhooks-mautic-zendesk/src/Server.ts
@@ -319,7 +319,7 @@ class Server {
         if (resultTicket) {
           this.dbg(`Success updated ticket "${resultTicket.data.ticket.id}".`);
 
-          if (tags) {
+          if (tags.length > 0) {
             const response = await addTagsToTicket(
               resultTicket.data.ticket.id,
               tags

--- a/packages/webhooks-mautic-zendesk/src/__tests__/BondeCreatedDate.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/BondeCreatedDate.spec.ts
@@ -1,0 +1,148 @@
+import BondeCreatedDate from "../integrations/BondeCreatedDate";
+import { checkNames, checkCep } from "../utils";
+
+describe("BondeCreatedData Class", () => {
+  describe("form entry not found for email, but there is name and cep from Mautic form results", () => {
+    it("should return name/cep from mautic and createdAt is current", async () => {
+      const bondeCreatedDate = new BondeCreatedDate(
+        "form_entry_not_found@email.com",
+        checkNames({
+          primeiro_nome: "Nádia",
+          sobrenome_completo: "de Lima"
+        }),
+        checkCep("30710456")
+      );
+      const bondeCreatedAt = await bondeCreatedDate.start([]);
+      expect(bondeCreatedAt).toHaveProperty("cep", "30710456");
+      expect(bondeCreatedAt).toHaveProperty("name", "Nádia de Lima");
+      expect(typeof bondeCreatedAt.createdAt === "string").toBe(true);
+    });
+  });
+  describe("form entry not found for email, there's no cep from Mautic form results but but there's a name ", () => {
+    it("should return createdAt: now, cep undefined and Mautic form name", async () => {
+      const bondeCreatedDate = new BondeCreatedDate(
+        "form_entry_not_found@email.com",
+        checkNames({
+          primeiro_nome: "Gabriela",
+          sobrenome_completo: "Caetano"
+        }),
+        checkCep(undefined)
+      );
+      const bondeCreatedAt = await bondeCreatedDate.start([]);
+      expect(bondeCreatedAt).toHaveProperty("cep", undefined);
+      expect(bondeCreatedAt).toHaveProperty("name", "Gabriela Caetano");
+      expect(typeof bondeCreatedAt.createdAt === "string").toBe(true);
+    });
+  });
+  describe("form entry not found for email and there's no name or cep from Mautic form results", () => {
+    it("should return createdAt: now, name: sem nome and cep undefined", async () => {
+      const bondeCreatedDate = new BondeCreatedDate(
+        "form_entry_not_found@email.com",
+        checkNames({
+          primeiro_nome: "",
+          sobrenome_completo: ""
+        }),
+        checkCep(undefined)
+      );
+      const bondeCreatedAt = await bondeCreatedDate.start([]);
+      expect(bondeCreatedAt).toHaveProperty("cep", undefined);
+      expect(bondeCreatedAt).toHaveProperty("name", "sem nome");
+      expect(typeof bondeCreatedAt.createdAt === "string").toBe(true);
+    });
+  });
+  describe("form entry found, but there's no cep from Mautic form results", () => {
+    it("should return name from Mautic, cep and createdAt from form_entry", async () => {
+      const bondeCreatedDate = new BondeCreatedDate(
+        "form_entry_found@email.com",
+        checkNames({
+          primeiro_nome: "Ana",
+          sobrenome_completo: "Moniz"
+        }),
+        checkCep(undefined)
+      );
+      const bondeCreatedAt = await bondeCreatedDate.start([
+        {
+          fields: JSON.stringify([
+            {
+              uid: "field-1533735752669-39",
+              kind: "email",
+              label: "SEU MELHOR EMAIL",
+              placeholder: "",
+              required: "true",
+              value: "form_entry_found@email.com"
+            },
+            {
+              uid: "field-1533735803691-45",
+              kind: "text",
+              label: "CEP DE ATENDIMENTO (Só números)",
+              placeholder: "",
+              required: "true",
+              value: "02202030"
+            }
+          ]),
+          created_at: "2020-08-11 20:11:08.963001",
+          widget_id: 17633
+        }
+      ]);
+      expect(bondeCreatedAt).toHaveProperty("cep", "02202030");
+      expect(bondeCreatedAt).toHaveProperty("name", "Ana Moniz");
+      expect(typeof bondeCreatedAt.createdAt === "string").toBe(true);
+    });
+  });
+  describe("form entry found, and there's name and cep from Mautic form results", () => {
+    it("should return createdAt from form_entries and name/cep from Mautic results", async () => {
+      const bondeCreatedDate = new BondeCreatedDate(
+        "form_entry_found@email.com",
+        checkNames({
+          primeiro_nome: "Fátima",
+          sobrenome_completo: "Furtado"
+        }),
+        checkCep("11075600")
+      );
+      const bondeCreatedAt = await bondeCreatedDate.start([
+        {
+          fields: JSON.stringify([
+            {
+              uid: "field-1533735752669-39",
+              kind: "email",
+              label: "SEU MELHOR EMAIL",
+              placeholder: "",
+              required: "true",
+              value: "form_entry_found@email.com"
+            },
+            {
+              uid: "field-1533735803691-45",
+              kind: "text",
+              label: "CEP DE ATENDIMENTO (Só números)",
+              placeholder: "",
+              required: "true",
+              value: "11075601"
+            },
+            {
+              uid: "field-1533735738039-59",
+              kind: "text",
+              label: "NOME",
+              placeholder: "",
+              required: "true",
+              value: "Fatima"
+            },
+
+            {
+              uid: "field-1533735745400-14",
+              kind: "text",
+              label: "SOBRENOME",
+              placeholder: "",
+              required: "true",
+              value: "Frutado"
+            }
+          ]),
+          created_at: "2020-09-16T21:03:44.543Z",
+          widget_id: 17633
+        }
+      ]);
+      expect(bondeCreatedAt).toHaveProperty("cep", "11075600");
+      expect(bondeCreatedAt).toHaveProperty("name", "Fátima Furtado");
+      expect(typeof bondeCreatedAt.createdAt === "string").toBe(true);
+    });
+  });
+});

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -1,0 +1,137 @@
+import { verificaDiretrizesAtendimento, verificaEstudoDeCaso } from "../utils";
+import { CONDITION } from "../types";
+
+describe("User condition status verification", () => {
+  const responses = {
+    aprovada: {
+      one: {
+        todos_os_atendimentos_rea: "aceito",
+        as_voluntarias_do_mapa_do: "compreendo",
+        o_comprometimento_a_dedic: "sim",
+        o_mapa_do_acolhimento_ent: "sim",
+        para_que_as_mulheres_que: "sim",
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "A",
+        durante_os_encontros_ana: "A",
+        durante_os_atendimentos_a: "A"
+      },
+      two: {
+        todos_os_atendimentos_rea: "aceito",
+        as_voluntarias_do_mapa_do: "compreendo",
+        o_comprometimento_a_dedic: "sim",
+        o_mapa_do_acolhimento_ent: "sim",
+        para_que_as_mulheres_que: "sim",
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "B",
+        durante_os_encontros_ana: "A",
+        durante_os_atendimentos_a: "A"
+      },
+      three: {
+        todos_os_atendimentos_rea: "aceito",
+        as_voluntarias_do_mapa_do: "compreendo",
+        o_comprometimento_a_dedic: "sim",
+        o_mapa_do_acolhimento_ent: "sim",
+        para_que_as_mulheres_que: "sim",
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "B",
+        durante_os_encontros_ana: "B",
+        durante_os_atendimentos_a: "A"
+      }
+    },
+    reprovada_diretrizes_do_mapa: {
+      one: {
+        todos_os_atendimentos_rea: "aceito",
+        as_voluntarias_do_mapa_do: "compreendo",
+        o_comprometimento_a_dedic: "sim",
+        o_mapa_do_acolhimento_ent: "nao",
+        para_que_as_mulheres_que: "sim",
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "A",
+        durante_os_encontros_ana: "B",
+        durante_os_atendimentos_a: "A"
+      },
+      two: {
+        todos_os_atendimentos_rea: "aceito",
+        as_voluntarias_do_mapa_do: "compreendo",
+        o_comprometimento_a_dedic: "nao",
+        o_mapa_do_acolhimento_ent: "sim",
+        para_que_as_mulheres_que: "sim",
+        qual_sua_area_de_atuacao: "psicologia-clinica",
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "B",
+        durante_os_encontros_ana: "C",
+        durante_os_atendimentos_a: "A"
+      }
+    },
+    reprovada_estudo_de_caso: {
+      one: {
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "C",
+        durante_os_encontros_ana: "B",
+        durante_os_atendimentos_a: "A"
+      },
+      two: {
+        no_seu_primeiro_atendimen: "A",
+        para_voce_o_que_e_mais_im: "C",
+        durante_os_encontros_ana: "A",
+        durante_os_atendimentos_a: "A"
+      }
+    }
+  };
+  describe("verificaDiretrizesAtendimento", () => {
+    it("should approve the user", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaDiretrizesAtendimento(condition, responses.aprovada.one);
+      expect(condition).toStrictEqual([CONDITION.UNSET]);
+    });
+    it("should change condition to reprovada_diretrizes_do_mapa -> 1", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaDiretrizesAtendimento(
+        condition,
+        responses.reprovada_diretrizes_do_mapa.one
+      );
+      expect(condition).toStrictEqual([CONDITION.REPROVADA_DIRETRIZES_DO_MAPA]);
+    });
+    it("should change condition to reprovada_diretrizes_do_mapa -> 2", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaDiretrizesAtendimento(
+        condition,
+        responses.reprovada_diretrizes_do_mapa.two
+      );
+      expect(condition).toStrictEqual([CONDITION.REPROVADA_DIRETRIZES_DO_MAPA]);
+    });
+  });
+
+  describe("verificaEstudoDeCaso", () => {
+    it("should approve the user", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaEstudoDeCaso(condition, responses.aprovada.two);
+      expect(condition).toStrictEqual([CONDITION.UNSET]);
+    });
+    it("should change condition to reprovada_estudo_de_caso -> 1", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaEstudoDeCaso(
+        condition,
+        responses.reprovada_estudo_de_caso.one
+      );
+      expect(condition).toStrictEqual([CONDITION.REPROVADA_ESTUDO_DE_CASO]);
+    });
+    it("should change condition to reprovada_estudo_de_caso -> 2", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaEstudoDeCaso(
+        condition,
+        responses.reprovada_estudo_de_caso.two
+      );
+      expect(condition).toStrictEqual([CONDITION.REPROVADA_ESTUDO_DE_CASO]);
+    });
+  });
+
+  describe("aprovada", () => {
+    it("should approve the user", async () => {
+      const condition: [CONDITION] = [CONDITION.UNSET];
+      await verificaEstudoDeCaso(condition, responses.aprovada.three);
+      verificaDiretrizesAtendimento(condition, responses.aprovada.three);
+      expect(condition).toStrictEqual([CONDITION.UNSET]);
+    });
+  });
+});

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -143,44 +143,28 @@ describe("User condition status verification", () => {
 describe("Checks geolocation process logic", () => {
   describe("verificaLocalização", () => {
     describe("cep falsy", () => {
-      it("should change condition to reprovada_registro_invalido", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        await verificaLocalização(condition, {});
-        await verificaLocalização(condition, { cep: null });
-        await verificaLocalização(condition, { cep: undefined });
-        expect(condition).toStrictEqual([
-          CONDITION.REPROVADA_REGISTRO_INVÁLIDO
-        ]);
+      it("should add to the tags array the value 'cep-incorreto'", async () => {
+        const data1 = await verificaLocalização({});
+        const data2 = await verificaLocalização({ cep: null });
+        const data3 = await verificaLocalização({ cep: undefined });
+        expect(data1).toHaveProperty("tags", ["cep-incorreto"]);
+        expect(data2).toHaveProperty("tags", ["cep-incorreto"]);
+        expect(data3).toHaveProperty("tags", ["cep-incorreto"]);
       });
     });
     describe("GM returns ZERO_RESULTS", () => {
-      it("should change condition to reprovada_registro_invalido", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        await verificaLocalização(condition, { cep: "42709-200" });
-        expect(condition).toStrictEqual([
-          CONDITION.REPROVADA_REGISTRO_INVÁLIDO
-        ]);
-      });
       it("variable 'tags' has value '[cep-incorreto]'", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        const data = await verificaLocalização(condition, { cep: "42250579" });
+        const data = await verificaLocalização({ cep: "42250579" });
         expect(data).toHaveProperty("tags", ["cep-incorreto"]);
       });
     });
     describe("GM returns a valid response", () => {
-      it("should not change condition", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        await verificaLocalização(condition, { cep: "04121-000" });
-        expect(condition).toStrictEqual([CONDITION.UNSET]);
-      });
-      it("variable 'tags' is undefined", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        const data = await verificaLocalização(condition, { cep: "66093-672" });
-        expect(data).toHaveProperty("tags", undefined);
+      it("'tags' array is empty", async () => {
+        const data = await verificaLocalização({ cep: "66093-672" });
+        expect(data).toHaveProperty("tags", []);
       });
       it("latitude and longitude is not null", async () => {
-        const condition: [CONDITION] = [CONDITION.UNSET];
-        const data = await verificaLocalização(condition, { cep: "66093-672" });
+        const data = await verificaLocalização({ cep: "66093-672" });
         expect(data.latitude).not.toBe(null);
         expect(data.longitude).not.toBe(null);
       });

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -1,7 +1,9 @@
 import {
   verificaDiretrizesAtendimento,
   verificaEstudoDeCaso,
-  verificaLocalização
+  verificaLocalização,
+  checkNames,
+  filterByEmail
 } from "../utils";
 import { CONDITION } from "../types";
 
@@ -168,6 +170,120 @@ describe("Checks geolocation process logic", () => {
         expect(data.latitude).not.toBe(null);
         expect(data.longitude).not.toBe(null);
       });
+    });
+  });
+});
+
+describe("checkNames", () => {
+  describe("first and lastname are in arrays", () => {
+    it("should return a string of names", () => {
+      expect(
+        checkNames({
+          primeiro_nome: ["Nome", "Nome"],
+          sobrenome_completo: ["Teste", "Teste"]
+        })
+      ).toStrictEqual("Nome,Nome Teste,Teste");
+    });
+  });
+  describe("first and lastname are in strings", () => {
+    it("should return a string of names", () => {
+      expect(
+        checkNames({
+          primeiro_nome: "Nome",
+          sobrenome_completo: "Teste"
+        })
+      ).toStrictEqual("Nome Teste");
+    });
+  });
+  describe("first and lastname empty", () => {
+    it("should return null", () => {
+      expect(
+        checkNames({
+          primeiro_nome: "",
+          sobrenome_completo: ""
+        })
+      ).toStrictEqual(null);
+    });
+  });
+});
+
+describe("filterByEmail", () => {
+  const entries = [
+    {
+      fields:
+        '[{"uid":"field-1533733461113-5","kind":"text","label":"NOME","placeholder":"","required":"true","value":"Hermínia"},{"uid":"field-1533733485653-99","kind":"text","label":"SOBRENOME","placeholder":"","required":"true","value":"Amorim"},{"uid":"field-1533733493037-11","kind":"email","label":"SEU MELHOR EMAIL","placeholder":"","required":"true","value":"herminia.amorim@email.com"},{"uid":"field-1533733501716-34","kind":"text","label":"CRP (Só números)","placeholder":"","required":"true","value":"000000"},{"uid":"field-1533733650118-7","kind":"text","label":"CEP DE ATENDIMENTO (Só números)","placeholder":"","required":"true","value":"22461010"},{"uid":"field-1533734419113-13","kind":"text","label":"TELEFONE PARA ATENDIMENTO (COM DDD)","placeholder":"","required":"true","value":"1212121212"},{"uid":"field-1533734468460-38","kind":"text","label":"WHATSAPP (COM DDD)","placeholder":"Obrigatório para contato com a equipe","required":"true","value":"1212121212"},{"uid":"field-1533734495315-40","kind":"dropdown","label":"Como voluntária do Mapa do Acolhimento, você se dispõe a atender, pelo menos, uma (1) mulher que precisa de ajuda. Caso você tenha mais tempo disponível, você pode atender mais de uma (1) mulher, de maneira concomitante. Lembrando que os atendimentos devem ser sempre individuais. Quantas vagas você pode oferecer para atender, simultaneamente, mulheres do Mapa do Acolhimento?","placeholder":"1, 2, 3, 4, 5 ou mais","required":"true","value":"2"}]',
+      created_at: "2020-09-16T19:49:59.848563",
+      widget_id: 17628
+    },
+    {
+      fields:
+        '[{"uid":"field-1533733461113-5","kind":"text","label":"NOME","placeholder":"","required":"true","value":"Lígia"},{"uid":"field-1533733485653-99","kind":"text","label":"SOBRENOME","placeholder":"","required":"true","value":"Garcia"},{"uid":"field-1533733493037-11","kind":"email","label":"SEU MELHOR EMAIL","placeholder":"","required":"true","value":"ligia.garcia@email.com"},{"uid":"field-1533733501716-34","kind":"text","label":"CRP (Só números)","placeholder":"","required":"true","value":"0000000"},{"uid":"field-1533733650118-7","kind":"text","label":"CEP DE ATENDIMENTO (Só números)","placeholder":"","required":"true","value":"61760-906"},{"uid":"field-1533734419113-13","kind":"text","label":"TELEFONE PARA ATENDIMENTO (COM DDD)","placeholder":"","required":"true","value":"1212121212"},{"uid":"field-1533734468460-38","kind":"text","label":"WHATSAPP (COM DDD)","placeholder":"Obrigatório para contato com a equipe","required":"true","value":"1212121212"},{"uid":"field-1533734495315-40","kind":"dropdown","label":"Como voluntária do Mapa do Acolhimento, você se dispõe a atender, pelo menos, uma (1) mulher que precisa de ajuda. Caso você tenha mais tempo disponível, você pode atender mais de uma (1) mulher, de maneira concomitante. Lembrando que os atendimentos devem ser sempre individuais. Quantas vagas você pode oferecer para atender, simultaneamente, mulheres do Mapa do Acolhimento?","placeholder":"1, 2, 3, 4, 5 ou mais","required":"true","value":"2"}]',
+      created_at: "2020-09-16T00:47:23.429155",
+      widget_id: 17628
+    },
+    {
+      fields:
+        '[{"uid":"field-1533733461113-5","kind":"text","label":"NOME","placeholder":"","required":"true","value":"Teresa"},{"uid":"field-1533733485653-99","kind":"text","label":"SOBRENOME","placeholder":"","required":"true","value":"Nascimento"},{"uid":"field-1533733493037-11","kind":"email","label":"SEU MELHOR EMAIL","placeholder":"","required":"true","value":"teresa.nascimento@email.com"},{"uid":"field-1533733501716-34","kind":"text","label":"CRP (Só números)","placeholder":"","required":"true","value":"08/06886"},{"uid":"field-1533733650118-7","kind":"text","label":"CEP DE ATENDIMENTO (Só números)","placeholder":"","required":"true","value":"82300332"},{"uid":"field-1533734419113-13","kind":"text","label":"TELEFONE PARA ATENDIMENTO (COM DDD)","placeholder":"","required":"true","value":"1212121212"},{"uid":"field-1533734468460-38","kind":"text","label":"WHATSAPP (COM DDD)","placeholder":"Obrigatório para contato com a equipe","required":"true","value":"1212121212"},{"uid":"field-1533734495315-40","kind":"dropdown","label":"Como voluntária do Mapa do Acolhimento, você se dispõe a atender, pelo menos, uma (1) mulher que precisa de ajuda. Caso você tenha mais tempo disponível, você pode atender mais de uma (1) mulher, de maneira concomitante. Lembrando que os atendimentos devem ser sempre individuais. Quantas vagas você pode oferecer para atender, simultaneamente, mulheres do Mapa do Acolhimento?","placeholder":"1, 2, 3, 4, 5 ou mais","required":"true","value":"2"}]',
+      created_at: "2020-09-15T18:47:28.387207",
+      widget_id: 17628
+    },
+    {
+      fields:
+        '[{"uid":"field-1533733461113-5","kind":"text","label":"NOME","placeholder":"","required":"true","value":"Angélica"},{"uid":"field-1533733485653-99","kind":"text","label":"SOBRENOME","placeholder":"","required":"true","value":"Lopes"},{"uid":"field-1533733493037-11","kind":"email","label":"SEU MELHOR EMAIL","placeholder":"","required":"true","value":"angelica.lopes@email.com"},{"uid":"field-1533733501716-34","kind":"text","label":"CRP (Só números)","placeholder":"","required":"true","value":"00000000000"},{"uid":"field-1533733650118-7","kind":"text","label":"CEP DE ATENDIMENTO (Só números)","placeholder":"","required":"true","value":"05422030"},{"uid":"field-1533734419113-13","kind":"text","label":"TELEFONE PARA ATENDIMENTO (COM DDD)","placeholder":"","required":"true","value":"12121212"},{"uid":"field-1533734468460-38","kind":"text","label":"WHATSAPP (COM DDD)","placeholder":"Obrigatório para contato com a equipe","required":"true","value":"12121212"},{"uid":"field-1533734495315-40","kind":"dropdown","label":"Como voluntária do Mapa do Acolhimento, você se dispõe a atender, pelo menos, uma (1) mulher que precisa de ajuda. Caso você tenha mais tempo disponível, você pode atender mais de uma (1) mulher, de maneira concomitante. Lembrando que os atendimentos devem ser sempre individuais. Quantas vagas você pode oferecer para atender, simultaneamente, mulheres do Mapa do Acolhimento?","placeholder":"1, 2, 3, 4, 5 ou mais","required":"true","value":"1"}]',
+      created_at: "2020-09-14T22:10:46.092246",
+      widget_id: 17628
+    }
+  ];
+  describe("there's an entry with that e-mail", () => {
+    it("should return an object with email/name/lastname/cep, part. 3", () => {
+      const data = filterByEmail(entries, "herminia.amorim@email.com");
+      expect(data).toHaveProperty("email", "herminia.amorim@email.com");
+      expect(data).toHaveProperty("cep", "22461010");
+      expect(data).toHaveProperty("lastname", "Amorim");
+      expect(data).toHaveProperty("name", "Hermínia");
+    });
+    it("should return an object with email/name/lastname/cep, part. 4", () => {
+      const data = filterByEmail(entries, "ligia.garcia@email.com");
+      expect(data).toHaveProperty("email", "ligia.garcia@email.com");
+      expect(data).toHaveProperty("cep", "61760-906");
+      expect(data).toHaveProperty("lastname", "Garcia");
+      expect(data).toHaveProperty("name", "Lígia");
+    });
+    it("should return an object with email/name/lastname/cep, part. 2", () => {
+      const data = filterByEmail(entries, "teresa.nascimento@email.com");
+      expect(data).toHaveProperty("email", "teresa.nascimento@email.com");
+      expect(data).toHaveProperty("cep", "82300332");
+      expect(data).toHaveProperty("lastname", "Nascimento");
+      expect(data).toHaveProperty("name", "Teresa");
+    });
+    it("should return an object with email/name/lastname/cep, part. 1", () => {
+      const data = filterByEmail(entries, "angelica.lopes@email.com");
+      expect(data).toHaveProperty("email", "angelica.lopes@email.com");
+      expect(data).toHaveProperty("cep", "05422030");
+      expect(data).toHaveProperty("lastname", "Lopes");
+      expect(data).toHaveProperty("name", "Angélica");
+    });
+  });
+  describe("there's no entry with that e-mail", () => {
+    it("should return undefined, part. 1", () => {
+      expect(filterByEmail(entries, "nossas@email.com")).toStrictEqual(
+        undefined
+      );
+    });
+    it("should return undefined, part. 2", () => {
+      expect(filterByEmail(entries, "bonde@email.com")).toStrictEqual(
+        undefined
+      );
+    });
+    it("should return undefined, part. 3", () => {
+      expect(filterByEmail(entries, "teste@email.com")).toStrictEqual(
+        undefined
+      );
+    });
+    it("should return undefined, part. 4", () => {
+      expect(filterByEmail(entries, "ligia.garci@email.com")).toStrictEqual(
+        undefined
+      );
     });
   });
 });

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -143,12 +143,26 @@ describe("User condition status verification", () => {
 });
 
 describe("Checks geolocation process logic", () => {
+  const mockGetGeolocationReject = jest.fn().mockResolvedValue({
+    latitude: null,
+    longitude: null
+  });
+  const mockGetGeolocationResolve = jest.fn().mockResolvedValue({
+    latitude: "-30.0314405",
+    longitude: "-51.21005779999999"
+  });
   describe("verificaLocalização", () => {
     describe("cep falsy", () => {
       it("should add to the tags array the value 'cep-incorreto'", async () => {
-        const data1 = await verificaLocalização({});
-        const data2 = await verificaLocalização({ cep: null });
-        const data3 = await verificaLocalização({ cep: undefined });
+        const data1 = await verificaLocalização({}, mockGetGeolocationReject);
+        const data2 = await verificaLocalização(
+          { cep: null },
+          mockGetGeolocationReject
+        );
+        const data3 = await verificaLocalização(
+          { cep: undefined },
+          mockGetGeolocationReject
+        );
         expect(data1).toHaveProperty("tags", ["cep-incorreto"]);
         expect(data2).toHaveProperty("tags", ["cep-incorreto"]);
         expect(data3).toHaveProperty("tags", ["cep-incorreto"]);
@@ -156,17 +170,26 @@ describe("Checks geolocation process logic", () => {
     });
     describe("GM returns ZERO_RESULTS", () => {
       it("variable 'tags' has value '[cep-incorreto]'", async () => {
-        const data = await verificaLocalização({ cep: "42250579" });
+        const data = await verificaLocalização(
+          { cep: "42250579" },
+          mockGetGeolocationReject
+        );
         expect(data).toHaveProperty("tags", ["cep-incorreto"]);
       });
     });
     describe("GM returns a valid response", () => {
       it("'tags' array is empty", async () => {
-        const data = await verificaLocalização({ cep: "66093-672" });
+        const data = await verificaLocalização(
+          { cep: "66093-672" },
+          mockGetGeolocationResolve
+        );
         expect(data).toHaveProperty("tags", []);
       });
       it("latitude and longitude is not null", async () => {
-        const data = await verificaLocalização({ cep: "66093-672" });
+        const data = await verificaLocalização(
+          { cep: "66093-672" },
+          mockGetGeolocationResolve
+        );
         expect(data.latitude).not.toBe(null);
         expect(data.longitude).not.toBe(null);
       });

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -222,8 +222,8 @@ describe("checkNames", () => {
     it("should return null", () => {
       expect(
         checkNames({
-          primeiro_nome: "",
-          sobrenome_completo: ""
+          primeiro_nome: undefined,
+          sobrenome_completo: undefined
         })
       ).toStrictEqual(null);
     });

--- a/packages/webhooks-mautic-zendesk/src/beforeEachTest.ts
+++ b/packages/webhooks-mautic-zendesk/src/beforeEachTest.ts
@@ -1,0 +1,3 @@
+import dotenv from "dotenv";
+
+dotenv.config();

--- a/packages/webhooks-mautic-zendesk/src/getFormEntries.ts
+++ b/packages/webhooks-mautic-zendesk/src/getFormEntries.ts
@@ -1,0 +1,60 @@
+import axios from "axios";
+import * as yup from "yup";
+import debug from "debug";
+import { FormEntry } from "./types";
+
+const query = `query($widgets: [Int!]!) {
+  form_entries(where: {widget_id: {_in: $widgets}}) {
+    fields
+    created_at
+    widget_id
+  }
+}`;
+
+interface DataType {
+  data: {
+    form_entries: FormEntry[];
+  };
+}
+
+const dbg = debug("webhooks-mautic-zendesk-getFormEntries");
+
+const getFormEntries = async () => {
+  const { HASURA_API_URL, X_HASURA_ADMIN_SECRET, WIDGET_IDS } = process.env;
+  let widget_ids;
+  try {
+    widget_ids = WIDGET_IDS.split(",").map(Number);
+    if (
+      !yup
+        .array()
+        .of(yup.string())
+        .min(6)
+        .isValid(widget_ids)
+    ) {
+      throw new Error("Invalid WIDGET_IDS env var");
+    }
+  } catch (e) {
+    return dbg(e);
+  }
+  try {
+    const data = await axios.post<DataType>(
+      HASURA_API_URL!,
+      {
+        query,
+        variables: {
+          widgets: widget_ids
+        }
+      },
+      {
+        headers: {
+          "x-hasura-admin-secret": X_HASURA_ADMIN_SECRET
+        }
+      }
+    );
+    return data.data.data.form_entries;
+  } catch (e) {
+    return dbg(e);
+  }
+};
+
+export default getFormEntries;

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -49,7 +49,16 @@ class AdvogadaCreateUser extends Base {
         .from("insira_seu_numero_de_regi", "registration_number")
         .from("qual_sua_area_de_atuacao", "occupation_area")
         .transform(obj => {
-          const { email, phone, ...userFields } = obj;
+          const {
+            email,
+            phone,
+            latitude,
+            longitude,
+            address,
+            state,
+            city,
+            ...userFields
+          } = obj;
           let { disponibilidade_de_atendimentos } = obj;
           if (disponibilidade_de_atendimentos === "6") {
             disponibilidade_de_atendimentos = "5_ou_mais";
@@ -61,6 +70,12 @@ class AdvogadaCreateUser extends Base {
             organization_id: this.organizations[this.organization],
             user_fields: {
               ...removeFalsyValues(userFields),
+              cep,
+              address,
+              state,
+              city,
+              latitude,
+              longitude,
               data_de_inscricao_no_bonde: createdAt,
               ultima_atualizacao_de_dados: new Date().toString(),
               condition: condition[0] === "unset" ? "aprovada" : condition[0],

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -30,7 +30,7 @@ class AdvogadaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(condition, newData);
+    const validatedResult = await verificaLocalização(newData);
 
     const { tags } = validatedResult;
 

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { Response } from "express";
+import { getGeolocation } from "bonde-core-tools";
 import Base from "./Base";
 import { CONDITION } from "../types";
 import {
@@ -30,7 +31,7 @@ class AdvogadaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(newData);
+    const validatedResult = await verificaLocalização(newData, getGeolocation);
 
     const { tags } = validatedResult;
 

--- a/packages/webhooks-mautic-zendesk/src/integrations/BondeCreatedDate.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/BondeCreatedDate.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import * as yup from "yup";
 import debug from "debug";
+import { FormEntry } from "../types";
+import { filterByEmail } from "../utils";
 
 const query = `query($widgets: [Int!]!) {
   form_entries(where: {widget_id: {_in: $widgets}}) {
@@ -9,12 +11,6 @@ const query = `query($widgets: [Int!]!) {
     widget_id
   }
 }`;
-
-interface FormEntry {
-  fields: string;
-  created_at: string;
-  widget_id: number;
-}
 
 interface DataType {
   data: {
@@ -75,58 +71,21 @@ class BondeCreatedDate {
     }
   };
 
-  filterByEmail = (formEntries: FormEntry[]) =>
-    formEntries.filter(i => {
-      try {
-        const parsedFields = JSON.parse(i.fields);
-        return parsedFields[2].value === this.email;
-      } catch (e) {
-        return false;
-      }
-    });
-
   start = async () => {
     const formEntries = await this.getFormEntries();
     if (!formEntries) {
       return this.dbg("getFormEntries error");
     }
-    const filteredFormEntries = await this.filterByEmail(formEntries);
-    if (!filteredFormEntries) {
+
+    const filteredFormEntry = filterByEmail(formEntries, this.email);
+    if (!filteredFormEntry) {
       return this.dbg("filteredFormEntries error");
     }
 
     try {
-      const dicio = {
-        "field-1533735738039-59": "name",
-        "field-1464961964463-91": "name",
-        "field-1497368661426-82": "name",
-        "field-1530889190780-12": "name",
-        "field-1530889762581-19": "name",
-        "field-1533733461113-5": "name",
-        "field-1464961980231-76": "lastname",
-        "field-1533735745400-14": "lastname",
-        "field-1497368672826-91": "lastname",
-        "field-1530889199847-58": "lastname",
-        "field-1530889778477-47": "lastname",
-        "field-1533733485653-99": "lastname",
-        "field-1533735803691-45": "cep",
-        "field-1464962010023-34": "cep",
-        "field-1497369214092-68": "cep",
-        "field-1530889290557-13": "cep",
-        "field-1530889888615-19": "cep",
-        "field-1533733650118-7": "cep"
-      };
-      const fields = JSON.parse(filteredFormEntries[0].fields);
-      const userDetails = fields.reduce((newObj, old) => {
-        const key = dicio[old.uid] && dicio[old.uid];
-        return {
-          ...newObj,
-          [key]: old.value
-        };
-      }, {});
-      const { name, lastname, cep } = userDetails;
+      const { name, lastname, cep, created_at: createdAt } = filteredFormEntry;
       const aux = {
-        createdAt: filteredFormEntries[0].created_at,
+        createdAt,
         name:
           typeof this.name !== "string" || this.name.length === 0
             ? `${name} ${lastname}`

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { Response } from "express";
+import { getGeolocation } from "bonde-core-tools";
 import Base from "./Base";
 import { CONDITION } from "../types";
 import {
@@ -30,7 +31,7 @@ class PsicologaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(newData);
+    const validatedResult = await verificaLocalização(newData, getGeolocation);
 
     const { tags } = validatedResult;
 

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -30,7 +30,7 @@ class PsicologaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(condition, newData);
+    const validatedResult = await verificaLocalização(newData);
 
     const { tags } = validatedResult;
 

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -1,14 +1,13 @@
-import { getGeolocation } from "bonde-core-tools";
 import * as yup from "yup";
 import { Response } from "express";
 import Base from "./Base";
-
-export enum CONDITION {
-  UNSET = "unset",
-  REPROVADA_REGISTRO_INVÁLIDO = "reprovada_registro_inválido",
-  REPROVADA_DIRETRIZES_DO_MAPA = "reprovada_diretrizes_do_mapa",
-  REPROVADA_ESTUDO_DE_CASO = "reprovada_estudo_de_caso"
-}
+import { CONDITION } from "../types";
+import {
+  verificaEstudoDeCaso,
+  verificaLocalização,
+  verificaDiretrizesAtendimento,
+  removeFalsyValues
+} from "../utils";
 
 interface InputFromMautic {
   createdAt: string;
@@ -23,164 +22,15 @@ class PsicologaCreateUser extends Base {
     super("PsicólogaCreateUser", "users/create_or_update", res);
   }
 
-  private setCondition = (condition: [CONDITION], value: CONDITION) => {
-    const newCondition = condition;
-    if (condition[0] === CONDITION.UNSET) {
-      newCondition[0] = value;
-    }
-  };
-
-  private verificaDiretrizesAtendimento = async (
-    condition: [CONDITION],
-    data: Record<string, unknown>
-  ) => {
-    let newData = data;
-    const verificaCamposDiretrizesAtendimento = yup
-      .object()
-      .shape({
-        todos_os_atendimentos_rea: yup.string().required(),
-        as_voluntarias_do_mapa_do: yup.string().required(),
-        o_comprometimento_a_dedic: yup.string().required(),
-        o_mapa_do_acolhimento_ent: yup.string().required(),
-        para_que_as_mulheres_que: yup.string().required()
-      })
-      .required();
-
-    try {
-      await verificaCamposDiretrizesAtendimento.validate(newData, {
-        strict: true
-      });
-    } catch (e) {
-      this.setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
-    }
-
-    const verificaRespostasDiretrizesAtendimento = yup
-      .object()
-      .shape({
-        todos_os_atendimentos_rea: yup.string().matches(/aceito/),
-        as_voluntarias_do_mapa_do: yup.string().matches(/compreendo/),
-        o_comprometimento_a_dedic: yup.string().matches(/sim/),
-        o_mapa_do_acolhimento_ent: yup.string().matches(/sim/),
-        para_que_as_mulheres_que: yup.string().matches(/sim/)
-      })
-      .required();
-
-    if (!(await verificaRespostasDiretrizesAtendimento.isValid(newData))) {
-      this.setCondition(condition, CONDITION.REPROVADA_DIRETRIZES_DO_MAPA);
-    }
-
-    const stripDiretrizesAtendimento = yup
-      .object()
-      .shape({
-        todos_os_atendimentos_rea: yup.mixed().strip(true),
-        as_voluntarias_do_mapa_do: yup.mixed().strip(true),
-        o_comprometimento_a_dedic: yup.mixed().strip(true),
-        o_mapa_do_acolhimento_ent: yup.mixed().strip(true),
-        para_que_as_mulheres_que: yup.mixed().strip(true)
-      })
-      .required();
-
-    newData = stripDiretrizesAtendimento.cast(newData);
-
-    return newData;
-  };
-
-  private verificaEstudoDeCaso = async (
-    condition: [CONDITION],
-    data: object
-  ) => {
-    let newData = data;
-    const verificaCamposEstudoDeCaso = yup
-      .object()
-      .shape({
-        no_seu_primeiro_atendimen: yup.string().required(),
-        para_voce_o_que_e_mais_im: yup.string().required(),
-        durante_os_encontros_ana: yup.string().required(),
-        durante_os_atendimentos_a: yup.string().required()
-      })
-      .required();
-
-    try {
-      await verificaCamposEstudoDeCaso.validate(newData, {
-        strict: true
-      });
-    } catch (e) {
-      this.setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
-    }
-
-    const verificaRespostaEstudoDeCaso = yup
-      .object()
-      .shape({
-        no_seu_primeiro_atendimen: yup.string().matches(/A|B/),
-        para_voce_o_que_e_mais_im: yup.string().matches(/A|B/),
-        durante_os_encontros_ana: yup.string().matches(/A|B/),
-        durante_os_atendimentos_a: yup.string().matches(/A|B/)
-      })
-      .required();
-
-    if (!(await verificaRespostaEstudoDeCaso.isValid(newData))) {
-      this.setCondition(condition, CONDITION.REPROVADA_ESTUDO_DE_CASO);
-    }
-
-    const stripRespostaEstudoDeCaso = yup
-      .object()
-      .shape({
-        no_seu_primeiro_atendimen: yup.mixed().strip(true),
-        para_voce_o_que_e_mais_im: yup.mixed().strip(true),
-        durante_os_encontros_ana: yup.mixed().strip(true),
-        durante_os_atendimentos_a: yup.mixed().strip(true)
-      })
-      .required();
-
-    newData = await stripRespostaEstudoDeCaso.cast(newData);
-
-    return newData;
-  };
-
-  private verificaLocalização = async (
-    _condition: [CONDITION],
-    data: object
-  ) => {
-    const verificaCep = yup
-      .object()
-      .shape({
-        cep: yup.string().nullable()
-      })
-      .required();
-    let verifiedData;
-    try {
-      verifiedData = await verificaCep.validate(data);
-    } catch (e) {
-      return {};
-      // this.setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO)
-    }
-
-    const { latitude, longitude, ...rest } = await getGeolocation({
-      cep: verifiedData.cep,
-      email: verifiedData.email
-    });
-
-    const tags: string[] | undefined =
-      latitude === null || longitude === null ? ["cep-incorreto"] : undefined;
-
-    return {
-      ...verifiedData,
-      ...rest,
-      latitude,
-      longitude,
-      tags
-    };
-  };
-
   start = async (data, { createdAt, name, cep }: InputFromMautic) => {
     let newData = {
       ...data,
       cep
     };
     const condition: [CONDITION] = [CONDITION.UNSET];
-    newData = await this.verificaDiretrizesAtendimento(condition, newData);
-    newData = await this.verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await this.verificaLocalização(condition, newData);
+    newData = await verificaDiretrizesAtendimento(condition, newData);
+    newData = await verificaEstudoDeCaso(condition, newData);
+    const validatedResult = await verificaLocalização(condition, newData);
 
     const { tags } = validatedResult;
 
@@ -209,7 +59,7 @@ class PsicologaCreateUser extends Base {
             phone,
             organization_id: this.organizations[this.organization],
             user_fields: {
-              ...userFields,
+              ...removeFalsyValues(userFields),
               data_de_inscricao_no_bonde: createdAt,
               ultima_atualizacao_de_dados: new Date().toString(),
               condition: condition[0] === "unset" ? "aprovada" : condition[0],

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -49,7 +49,16 @@ class PsicologaCreateUser extends Base {
         .from("atualmente_quantas_mulher", "atendimentos_em_andamento")
         .from("quanto_atendimentos_pelo", "atendimentos_concluidos")
         .transform(obj => {
-          const { email, phone, ...userFields } = obj;
+          const {
+            email,
+            phone,
+            latitude,
+            longitude,
+            address,
+            state,
+            city,
+            ...userFields
+          } = obj;
           let { disponibilidade_de_atendimentos } = obj;
           if (disponibilidade_de_atendimentos === "6") {
             disponibilidade_de_atendimentos = "5_ou_mais";
@@ -61,6 +70,12 @@ class PsicologaCreateUser extends Base {
             organization_id: this.organizations[this.organization],
             user_fields: {
               ...removeFalsyValues(userFields),
+              cep,
+              address,
+              state,
+              city,
+              latitude,
+              longitude,
               data_de_inscricao_no_bonde: createdAt,
               ultima_atualizacao_de_dados: new Date().toString(),
               condition: condition[0] === "unset" ? "aprovada" : condition[0],

--- a/packages/webhooks-mautic-zendesk/src/types.ts
+++ b/packages/webhooks-mautic-zendesk/src/types.ts
@@ -1,0 +1,12 @@
+export enum CONDITION {
+  UNSET = "unset",
+  REPROVADA_REGISTRO_INVÁLIDO = "reprovada_registro_inválido",
+  REPROVADA_DIRETRIZES_DO_MAPA = "reprovada_diretrizes_do_mapa",
+  REPROVADA_ESTUDO_DE_CASO = "reprovada_estudo_de_caso"
+}
+
+export interface FormEntry {
+  fields: string;
+  created_at: string;
+  widget_id: number;
+}

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -1,4 +1,3 @@
-import { getGeolocation } from "bonde-core-tools";
 import * as yup from "yup";
 import { CONDITION, FormEntry } from "./types";
 
@@ -19,7 +18,7 @@ export const setTags = (tags: Array<string | never>, value: string) => {
 /**
  * TODO: adicionar tag cep_incorreto
  */
-export const verificaLocalização = async data => {
+export const verificaLocalização = async (data, getGeolocation) => {
   let newData = data;
   const tags: Array<string | never> = [];
   const verificaCep = yup

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -1,0 +1,238 @@
+import { getGeolocation } from "bonde-core-tools";
+import * as yup from "yup";
+import { CONDITION, FormEntry } from "./types";
+
+export const setCondition = (condition: [CONDITION], value: CONDITION) => {
+  const newCondition = condition;
+  if (newCondition[0] === CONDITION.UNSET) {
+    newCondition[0] = value;
+  }
+};
+
+/**
+ * TODO: adicionar tag cep_incorreto
+ */
+export const verificaLocalização = async (condition: [CONDITION], data) => {
+  let newData = data;
+  const verificaCep = yup
+    .object()
+    .shape({
+      cep: yup.string().nullable()
+    })
+    .required();
+  try {
+    newData = await verificaCep.validate(newData);
+  } catch (e) {
+    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+  }
+  const { latitude, longitude, ...rest } = await getGeolocation({
+    cep: newData.cep,
+    email: newData.email
+  });
+
+  if (latitude === null || longitude === null) {
+    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+  }
+
+  const tags: string[] | undefined =
+    latitude === null || longitude === null ? ["cep-incorreto"] : undefined;
+
+  return {
+    ...newData,
+    ...rest,
+    latitude,
+    longitude,
+    tags
+  };
+};
+
+export const verificaDiretrizesAtendimento = async (
+  condition: [CONDITION],
+  data: Record<string, unknown>
+) => {
+  let newData = data;
+  const verificaCamposDiretrizesAtendimento = yup
+    .object()
+    .shape({
+      todos_os_atendimentos_rea: yup.string().required(),
+      as_voluntarias_do_mapa_do: yup.string().required(),
+      o_comprometimento_a_dedic: yup.string().required(),
+      o_mapa_do_acolhimento_ent: yup.string().required(),
+      para_que_as_mulheres_que: yup.string().required()
+    })
+    .required();
+
+  try {
+    await verificaCamposDiretrizesAtendimento.validate(newData, {
+      strict: true
+    });
+  } catch (e) {
+    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+  }
+
+  const verificaRespostasDiretrizesAtendimento = yup
+    .object()
+    .shape({
+      todos_os_atendimentos_rea: yup.string().matches(/aceito/),
+      as_voluntarias_do_mapa_do: yup.string().matches(/compreendo/),
+      o_comprometimento_a_dedic: yup.string().matches(/sim/),
+      o_mapa_do_acolhimento_ent: yup.string().matches(/sim/),
+      para_que_as_mulheres_que: yup.string().matches(/sim/)
+    })
+    .required();
+
+  if (!(await verificaRespostasDiretrizesAtendimento.isValid(newData))) {
+    setCondition(condition, CONDITION.REPROVADA_DIRETRIZES_DO_MAPA);
+  }
+
+  const stripDiretrizesAtendimento = yup
+    .object()
+    .shape({
+      todos_os_atendimentos_rea: yup.mixed().strip(true),
+      as_voluntarias_do_mapa_do: yup.mixed().strip(true),
+      o_comprometimento_a_dedic: yup.mixed().strip(true),
+      o_mapa_do_acolhimento_ent: yup.mixed().strip(true),
+      para_que_as_mulheres_que: yup.mixed().strip(true)
+    })
+    .required();
+
+  newData = stripDiretrizesAtendimento.cast(newData);
+
+  return newData;
+};
+
+export const verificaEstudoDeCaso = async (
+  condition: [CONDITION],
+  data: object
+) => {
+  let newData = data;
+  const verificaCamposEstudoDeCaso = yup
+    .object()
+    .shape({
+      no_seu_primeiro_atendimen: yup.string().required(),
+      para_voce_o_que_e_mais_im: yup.string().required(),
+      durante_os_encontros_ana: yup.string().required(),
+      durante_os_atendimentos_a: yup.string().required()
+    })
+    .required();
+
+  try {
+    await verificaCamposEstudoDeCaso.validate(newData, {
+      strict: true
+    });
+  } catch (e) {
+    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+  }
+
+  const verificaRespostaEstudoDeCaso = yup
+    .object()
+    .shape({
+      no_seu_primeiro_atendimen: yup.string().matches(/A|B/),
+      para_voce_o_que_e_mais_im: yup.string().matches(/A|B/),
+      durante_os_encontros_ana: yup.string().matches(/A|B/),
+      durante_os_atendimentos_a: yup.string().matches(/A|B/)
+    })
+    .required();
+
+  if (!(await verificaRespostaEstudoDeCaso.isValid(newData))) {
+    setCondition(condition, CONDITION.REPROVADA_ESTUDO_DE_CASO);
+  }
+
+  const stripRespostaEstudoDeCaso = yup
+    .object()
+    .shape({
+      no_seu_primeiro_atendimen: yup.mixed().strip(true),
+      para_voce_o_que_e_mais_im: yup.mixed().strip(true),
+      durante_os_encontros_ana: yup.mixed().strip(true),
+      durante_os_atendimentos_a: yup.mixed().strip(true)
+    })
+    .required();
+
+  newData = stripRespostaEstudoDeCaso.cast(newData);
+
+  return newData;
+};
+
+export const removeFalsyValues = obj =>
+  Object.entries(obj).reduce((a, [k, v]) => (v ? ((a[k] = v), a) : a), {});
+
+export const checkNames = ({
+  primeiro_nome,
+  sobrenome_completo
+}: {
+  primeiro_nome: Array<string> | string;
+  sobrenome_completo: Array<string> | string;
+}) => {
+  let aux = "";
+  if (typeof primeiro_nome === "string" && primeiro_nome.length > 0) {
+    aux += `${primeiro_nome}`;
+  }
+
+  if (typeof sobrenome_completo === "string" && sobrenome_completo.length > 0) {
+    aux += ` ${sobrenome_completo}`;
+  }
+
+  if (aux.length > 0) {
+    return aux;
+  }
+
+  return null;
+};
+
+export const checkCep = (cep: string) => {
+  if (typeof cep === "string" && cep.length > 0) {
+    return cep;
+  }
+
+  return null;
+};
+
+export const filterByEmail = (
+  formEntries: FormEntry[],
+  email: string
+): {
+  name: string | null;
+  lastname: string | null;
+  cep: string | null;
+  created_at: string;
+  widget_id: number;
+} => {
+  const dicio = {
+    "field-1533735738039-59": "name",
+    "field-1464961964463-91": "name",
+    "field-1497368661426-82": "name",
+    "field-1530889190780-12": "name",
+    "field-1530889762581-19": "name",
+    "field-1533733461113-5": "name",
+    "field-1464961980231-76": "lastname",
+    "field-1533735745400-14": "lastname",
+    "field-1497368672826-91": "lastname",
+    "field-1530889199847-58": "lastname",
+    "field-1530889778477-47": "lastname",
+    "field-1533733485653-99": "lastname",
+    "field-1533735803691-45": "cep",
+    "field-1464962010023-34": "cep",
+    "field-1497369214092-68": "cep",
+    "field-1530889290557-13": "cep",
+    "field-1530889888615-19": "cep",
+    "field-1533733650118-7": "cep"
+  };
+  const getFieldsValue = formEntries.map(i => {
+    try {
+      const parsedFields = JSON.parse(i.fields);
+      return {
+        ...i,
+        ...parsedFields.reduce((newObj, old) => {
+          const key = dicio[old.uid] && dicio[old.uid];
+          return {
+            ...newObj,
+            [key]: old.value
+          };
+        }, {})
+      };
+    } catch (e) {
+      return false;
+    }
+  });
+  return getFieldsValue.find(f => f.email === email);
+};

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -17,7 +17,7 @@ export const verificaLocalização = async (condition: [CONDITION], data) => {
   const verificaCep = yup
     .object()
     .shape({
-      cep: yup.string().nullable()
+      cep: yup.string().required()
     })
     .required();
   try {
@@ -180,8 +180,8 @@ export const checkNames = ({
 };
 
 export const checkCep = (cep: string) => {
-  if (typeof cep === "string" && cep.length > 0) {
-    return cep;
+  if (cep.length > 0) {
+    return cep.toString();
   }
 
   return null;
@@ -190,13 +190,15 @@ export const checkCep = (cep: string) => {
 export const filterByEmail = (
   formEntries: FormEntry[],
   email: string
-): {
-  name: string | null;
-  lastname: string | null;
-  cep: string | null;
-  created_at: string;
-  widget_id: number;
-} => {
+):
+  | {
+      name: string | null;
+      lastname: string | null;
+      cep: string | null;
+      created_at: string;
+      widget_id: number;
+    }
+  | undefined => {
   const dicio = {
     "field-1533735738039-59": "name",
     "field-1464961964463-91": "name",

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -164,15 +164,15 @@ export const checkNames = ({
   primeiro_nome,
   sobrenome_completo
 }: {
-  primeiro_nome: Array<string> | string;
-  sobrenome_completo: Array<string> | string;
+  primeiro_nome?: Array<string> | string;
+  sobrenome_completo?: Array<string> | string;
 }) => {
   let aux = "";
-  if (primeiro_nome.length > 0) {
+  if (primeiro_nome && primeiro_nome.length > 0) {
     aux += `${primeiro_nome}`;
   }
 
-  if (sobrenome_completo.length > 0) {
+  if (sobrenome_completo && sobrenome_completo.length > 0) {
     aux += ` ${sobrenome_completo}`;
   }
 

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -169,11 +169,11 @@ export const checkNames = ({
   sobrenome_completo: Array<string> | string;
 }) => {
   let aux = "";
-  if (typeof primeiro_nome === "string" && primeiro_nome.length > 0) {
+  if (primeiro_nome.length > 0) {
     aux += `${primeiro_nome}`;
   }
 
-  if (typeof sobrenome_completo === "string" && sobrenome_completo.length > 0) {
+  if (sobrenome_completo.length > 0) {
     aux += ` ${sobrenome_completo}`;
   }
 
@@ -184,8 +184,8 @@ export const checkNames = ({
   return null;
 };
 
-export const checkCep = (cep: string) => {
-  if (cep.length > 0) {
+export const checkCep = (cep?: string) => {
+  if (cep && cep.length > 0) {
     return cep.toString();
   }
 
@@ -230,7 +230,7 @@ export const filterByEmail = (
       return {
         ...i,
         ...parsedFields.reduce((newObj, old) => {
-          const key = dicio[old.uid] && dicio[old.uid];
+          const key = (dicio[old.uid] && dicio[old.uid]) || old.kind;
           return {
             ...newObj,
             [key]: old.value
@@ -238,7 +238,8 @@ export const filterByEmail = (
         }, {})
       };
     } catch (e) {
-      return false;
+      console.log(e);
+      return undefined;
     }
   });
   return getFieldsValue.find(f => f.email === email);

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -9,11 +9,19 @@ export const setCondition = (condition: [CONDITION], value: CONDITION) => {
   }
 };
 
+export const setTags = (tags: Array<string | never>, value: string) => {
+  const newTags = tags;
+  if (!newTags[0]) {
+    newTags[0] = value;
+  }
+};
+
 /**
  * TODO: adicionar tag cep_incorreto
  */
-export const verificaLocalização = async (condition: [CONDITION], data) => {
+export const verificaLocalização = async data => {
   let newData = data;
+  const tags: Array<string | never> = [];
   const verificaCep = yup
     .object()
     .shape({
@@ -23,7 +31,7 @@ export const verificaLocalização = async (condition: [CONDITION], data) => {
   try {
     newData = await verificaCep.validate(newData);
   } catch (e) {
-    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+    setTags(tags, "cep-incorreto");
   }
   const { latitude, longitude, ...rest } = await getGeolocation({
     cep: newData.cep,
@@ -31,11 +39,8 @@ export const verificaLocalização = async (condition: [CONDITION], data) => {
   });
 
   if (latitude === null || longitude === null) {
-    setCondition(condition, CONDITION.REPROVADA_REGISTRO_INVÁLIDO);
+    setTags(tags, "cep-incorreto");
   }
-
-  const tags: string[] | undefined =
-    latitude === null || longitude === null ? ["cep-incorreto"] : undefined;
 
   return {
     ...newData,


### PR DESCRIPTION
This mautic-zendesk refactoring is necessary to improve code maintainability.

Due to some issues with incorrect zipcodes we needed to revisit the package, but it was shown to be very difficult to fix bugs when there was so much repeated code all over. 

Main functionalities like `verificaDiretrizesAtendimento`, `verificaEstudoDeCaso` and `verificaLocalização` repeated in `AdvogadaCreateUser` and `PsicologaCreateUser`.

These functions were placed in the `utils` file and tested.