### PR TITLE
Stops adding 'cep-incorreto' to tags

### DIFF
--- a/packages/webhooks-mautic-zendesk/src/Server.ts
+++ b/packages/webhooks-mautic-zendesk/src/Server.ts
@@ -12,7 +12,6 @@ import { FILTER_SERVICE_STATUS, filterService } from "./filterService";
 import { FILTER_FORM_NAME_STATUS, filterFormName } from "./filterFormName";
 import getFormEntries from "./getFormEntries";
 import BondeCreatedDate from "./integrations/BondeCreatedDate";
-import addTagsToTicket from "./zendesk/addTagsToTicket";
 import { checkNames, checkCep } from "./utils";
 
 // interface DataType {
@@ -304,8 +303,7 @@ class Server {
                 id: userId
               }
             }
-          },
-          tags
+          }
         } = user;
 
         // Save users in Mautic
@@ -325,18 +323,6 @@ class Server {
         )) as { data: { ticket: { id: number } } };
         if (resultTicket) {
           this.dbg(`Success updated ticket "${resultTicket.data.ticket.id}".`);
-
-          if (tags.length > 0) {
-            const response = await addTagsToTicket(
-              resultTicket.data.ticket.id,
-              tags
-            );
-            if (response && response.status === 200) {
-              this.dbg(
-                `Success add tag "${tags}" to ticket "${resultTicket.data.ticket.id}".`
-              );
-            }
-          }
 
           return res.status(200).json("Success finish integration");
         }

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -143,48 +143,37 @@ describe("User condition status verification", () => {
 });
 
 describe("Checks geolocation process logic", () => {
-  const mockGetGeolocationReject = jest.fn().mockResolvedValue({
-    latitude: null,
-    longitude: null
-  });
   const mockGetGeolocationResolve = jest.fn().mockResolvedValue({
     latitude: "-30.0314405",
     longitude: "-51.21005779999999"
   });
   describe("verificaLocalização", () => {
-    describe("cep falsy", () => {
-      it("should add to the tags array the value 'cep-incorreto'", async () => {
-        const data1 = await verificaLocalização({}, mockGetGeolocationReject);
-        const data2 = await verificaLocalização(
-          { cep: null },
-          mockGetGeolocationReject
-        );
-        const data3 = await verificaLocalização(
-          { cep: undefined },
-          mockGetGeolocationReject
-        );
-        expect(data1).toHaveProperty("tags", ["cep-incorreto"]);
-        expect(data2).toHaveProperty("tags", ["cep-incorreto"]);
-        expect(data3).toHaveProperty("tags", ["cep-incorreto"]);
-      });
-    });
-    describe("GM returns ZERO_RESULTS", () => {
-      it("variable 'tags' has value '[cep-incorreto]'", async () => {
-        const data = await verificaLocalização(
-          { cep: "42250579" },
-          mockGetGeolocationReject
-        );
-        expect(data).toHaveProperty("tags", ["cep-incorreto"]);
-      });
-    });
+    // describe("cep falsy", () => {
+    //   it("should add to the tags array the value 'cep-incorreto'", async () => {
+    //     const data1 = await verificaLocalização({}, mockGetGeolocationReject);
+    //     const data2 = await verificaLocalização(
+    //       { cep: null },
+    //       mockGetGeolocationReject
+    //     );
+    //     const data3 = await verificaLocalização(
+    //       { cep: undefined },
+    //       mockGetGeolocationReject
+    //     );
+    //     expect(data1).toHaveProperty("tags", ["cep-incorreto"]);
+    //     expect(data2).toHaveProperty("tags", ["cep-incorreto"]);
+    //     expect(data3).toHaveProperty("tags", ["cep-incorreto"]);
+    //   });
+    // });
+    // describe("GM returns ZERO_RESULTS", () => {
+    // it("variable 'tags' has value '[cep-incorreto]'", async () => {
+    //   const data = await verificaLocalização(
+    //     { cep: "42250579" },
+    //     mockGetGeolocationReject
+    //   );
+    //   expect(data).toHaveProperty("tags", ["cep-incorreto"]);
+    // });
+    // });
     describe("GM returns a valid response", () => {
-      it("'tags' array is empty", async () => {
-        const data = await verificaLocalização(
-          { cep: "66093-672" },
-          mockGetGeolocationResolve
-        );
-        expect(data).toHaveProperty("tags", []);
-      });
       it("latitude and longitude is not null", async () => {
         const data = await verificaLocalização(
           { cep: "66093-672" },

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -1,7 +1,7 @@
 import {
   verificaDiretrizesAtendimento,
   verificaEstudoDeCaso,
-  verificaLocalização,
+  verifyLocation,
   checkNames,
   filterByEmail
 } from "../utils";
@@ -147,15 +147,15 @@ describe("Checks geolocation process logic", () => {
     latitude: "-30.0314405",
     longitude: "-51.21005779999999"
   });
-  describe("verificaLocalização", () => {
+  describe("verifyLocation", () => {
     // describe("cep falsy", () => {
     //   it("should add to the tags array the value 'cep-incorreto'", async () => {
-    //     const data1 = await verificaLocalização({}, mockGetGeolocationReject);
-    //     const data2 = await verificaLocalização(
+    //     const data1 = await verifyLocation({}, mockGetGeolocationReject);
+    //     const data2 = await verifyLocation(
     //       { cep: null },
     //       mockGetGeolocationReject
     //     );
-    //     const data3 = await verificaLocalização(
+    //     const data3 = await verifyLocation(
     //       { cep: undefined },
     //       mockGetGeolocationReject
     //     );
@@ -166,7 +166,7 @@ describe("Checks geolocation process logic", () => {
     // });
     // describe("GM returns ZERO_RESULTS", () => {
     // it("variable 'tags' has value '[cep-incorreto]'", async () => {
-    //   const data = await verificaLocalização(
+    //   const data = await verifyLocation(
     //     { cep: "42250579" },
     //     mockGetGeolocationReject
     //   );
@@ -175,7 +175,7 @@ describe("Checks geolocation process logic", () => {
     // });
     describe("GM returns a valid response", () => {
       it("latitude and longitude is not null", async () => {
-        const data = await verificaLocalização(
+        const data = await verifyLocation(
           { cep: "66093-672" },
           mockGetGeolocationResolve
         );

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -5,7 +5,7 @@ import Base from "./Base";
 import { CONDITION } from "../types";
 import {
   verificaEstudoDeCaso,
-  verificaLocalização,
+  verifyLocation,
   verificaDiretrizesAtendimento,
   removeFalsyValues
 } from "../utils";
@@ -31,10 +31,7 @@ class AdvogadaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const userWithGeolocation = await verificaLocalização(
-      newData,
-      getGeolocation
-    );
+    const userWithGeolocation = await verifyLocation(newData, getGeolocation);
 
     try {
       const zendeskValidation = yup

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -31,9 +31,10 @@ class AdvogadaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(newData, getGeolocation);
-
-    const { tags } = validatedResult;
+    const userWithGeolocation = await verificaLocalização(
+      newData,
+      getGeolocation
+    );
 
     try {
       const zendeskValidation = yup
@@ -118,9 +119,12 @@ class AdvogadaCreateUser extends Base {
         })
         .required();
 
-      const zendeskData = await zendeskValidation.validate(validatedResult, {
-        stripUnknown: true
-      });
+      const zendeskData = await zendeskValidation.validate(
+        userWithGeolocation,
+        {
+          stripUnknown: true
+        }
+      );
 
       const dataToBeSent = {
         user: {
@@ -128,7 +132,6 @@ class AdvogadaCreateUser extends Base {
         }
       };
       return {
-        tags,
         response: await this.send(dataToBeSent)
       };
     } catch (e) {

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -5,7 +5,7 @@ import Base from "./Base";
 import { CONDITION } from "../types";
 import {
   verificaEstudoDeCaso,
-  verificaLocalização,
+  verifyLocation,
   verificaDiretrizesAtendimento,
   removeFalsyValues
 } from "../utils";
@@ -31,10 +31,7 @@ class PsicologaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const userWithGeolocation = await verificaLocalização(
-      newData,
-      getGeolocation
-    );
+    const userWithGeolocation = await verifyLocation(newData, getGeolocation);
 
     try {
       const zendeskValidation = yup

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -31,9 +31,10 @@ class PsicologaCreateUser extends Base {
     const condition: [CONDITION] = [CONDITION.UNSET];
     newData = await verificaDiretrizesAtendimento(condition, newData);
     newData = await verificaEstudoDeCaso(condition, newData);
-    const validatedResult = await verificaLocalização(newData, getGeolocation);
-
-    const { tags } = validatedResult;
+    const userWithGeolocation = await verificaLocalização(
+      newData,
+      getGeolocation
+    );
 
     try {
       const zendeskValidation = yup
@@ -118,9 +119,12 @@ class PsicologaCreateUser extends Base {
         })
         .required();
 
-      const zendeskData = await zendeskValidation.validate(validatedResult, {
-        stripUnknown: true
-      });
+      const zendeskData = await zendeskValidation.validate(
+        userWithGeolocation,
+        {
+          stripUnknown: true
+        }
+      );
 
       const dataToBeSent = {
         user: {
@@ -128,7 +132,6 @@ class PsicologaCreateUser extends Base {
         }
       };
       return {
-        tags,
         response: await this.send(dataToBeSent)
       };
     } catch (e) {

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -11,7 +11,7 @@ export const setCondition = (condition: [CONDITION], value: CONDITION) => {
 /**
  * TODO: adicionar tag cep_incorreto
  */
-export const verificaLocalização = async (data, getGeolocation) => {
+export const verifyLocation = async (data, getGeolocation) => {
   const geolocationData = await getGeolocation({
     cep: data.cep,
     email: data.email

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -8,45 +8,18 @@ export const setCondition = (condition: [CONDITION], value: CONDITION) => {
   }
 };
 
-export const setTags = (tags: Array<string | never>, value: string) => {
-  const newTags = tags;
-  if (!newTags[0]) {
-    newTags[0] = value;
-  }
-};
-
 /**
  * TODO: adicionar tag cep_incorreto
  */
 export const verificaLocalização = async (data, getGeolocation) => {
-  let newData = data;
-  const tags: Array<string | never> = [];
-  const verificaCep = yup
-    .object()
-    .shape({
-      cep: yup.string().required()
-    })
-    .required();
-  try {
-    newData = await verificaCep.validate(newData);
-  } catch (e) {
-    setTags(tags, "cep-incorreto");
-  }
-  const { latitude, longitude, ...rest } = await getGeolocation({
-    cep: newData.cep,
-    email: newData.email
+  const geolocationData = await getGeolocation({
+    cep: data.cep,
+    email: data.email
   });
 
-  if (latitude === null || longitude === null) {
-    setTags(tags, "cep-incorreto");
-  }
-
   return {
-    ...newData,
-    ...rest,
-    latitude,
-    longitude,
-    tags
+    ...data,
+    ...geolocationData
   };
 };
 


### PR DESCRIPTION
This process is done automatically as a Zendesk trigger, and should not be done by the code.

The trigger in Zendesk finds users that don't have the the fields latitude / longitude, adds a 'cep-incorreto' tag to them and send them a message. Therefore, this tag shouldn't be added here because then the message asking for their correct zip code is never sent to the volunteer.