### PR TITLE
Users get a 0 count in calculado fields

### DIFF
--- a/packages/cli-zendesk/src/__tests__/countTickets.spec.ts
+++ b/packages/cli-zendesk/src/__tests__/countTickets.spec.ts
@@ -183,4 +183,45 @@ describe("check if countTickets calculate fields correctly", () => {
     const count = await countTickets(data as any);
     expect(count).toStrictEqual(expectedResult);
   });
+
+  it("should calculate the 'calculado' fields with 0 values", async () => {
+    const data = [
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "atendimento__iniciado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "atendimento__iniciado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "encaminhamento__realizado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status: "closed",
+        status_acolhimento: "encaminhamento__realizado",
+        organization_id: 360282119532
+      }
+    ];
+
+    const expectedResult = {
+      "377501500792": {
+        id: 377501500792,
+        atendimentos_em_andamento_calculado_: 0,
+        atendimentos_concludos_calculado_: 0,
+        encaminhamentos_realizados_calculado_: 0
+      }
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const count = await countTickets(data as any);
+    expect(count).toStrictEqual(expectedResult);
+  });
 });

--- a/packages/cli-zendesk/src/countTickets.ts
+++ b/packages/cli-zendesk/src/countTickets.ts
@@ -9,43 +9,44 @@ import { Ticket } from "./interfaces/Ticket";
 */
 const countTickets = async (tickets: Ticket[]): Promise<Requesters> => {
   const requesters: Requesters = {};
-  const promises = tickets
-    .filter(
-      i =>
-        i.status !== "deleted" && i.status !== "solved" && i.status !== "closed"
-    )
-    .map(async i => {
-      const organization_id = await verifyOrganization(i);
+  const promises = tickets.map(async i => {
+    const organization_id = await verifyOrganization(i);
 
-      if (organization_id !== null) {
-        // Cria um pivô e inicializa o valor
-        let requester = requesters[i.requester_id];
-        if (!requesters[i.requester_id]) {
-          requesters[i.requester_id] = {
-            id: i.requester_id,
-            atendimentos_em_andamento_calculado_: 0,
-            atendimentos_concludos_calculado_: 0,
-            encaminhamentos_realizados_calculado_: 0
-          };
-          requester = requesters[i.requester_id];
-        }
-        // Atualiza os atendimentos em andamento:
-        switch (i.status_acolhimento) {
-          case "atendimento__iniciado":
-            requester.atendimentos_em_andamento_calculado_ += 1;
-            break;
-          case "atendimento__concluído":
-            requester.atendimentos_concludos_calculado_ += 1;
-            break;
-          case "encaminhamento__realizado":
-          case "encaminhamento__realizado_para_serviço_público":
-            requester.encaminhamentos_realizados_calculado_ += 1;
-            break;
-          default:
-            return;
-        }
+    // Cria um pivô e inicializa o valor
+    let requester = requesters[i.requester_id];
+    if (!requesters[i.requester_id]) {
+      requesters[i.requester_id] = {
+        id: i.requester_id,
+        atendimentos_em_andamento_calculado_: 0,
+        atendimentos_concludos_calculado_: 0,
+        encaminhamentos_realizados_calculado_: 0
+      };
+      requester = requesters[i.requester_id];
+    }
+
+    if (
+      organization_id !== null &&
+      i.status !== "deleted" &&
+      i.status !== "solved" &&
+      i.status !== "closed"
+    ) {
+      // Atualiza os atendimentos em andamento:
+      switch (i.status_acolhimento) {
+        case "atendimento__iniciado":
+          requester.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento__concluído":
+          requester.atendimentos_concludos_calculado_ += 1;
+          break;
+        case "encaminhamento__realizado":
+        case "encaminhamento__realizado_para_serviço_público":
+          requester.encaminhamentos_realizados_calculado_ += 1;
+          break;
+        default:
+          return;
       }
-    });
+    }
+  });
 
   await Promise.all(promises);
   return requesters;

--- a/packages/webhooks-solidarity-count/src/__tests__/countTicket.spec.ts
+++ b/packages/webhooks-solidarity-count/src/__tests__/countTicket.spec.ts
@@ -122,4 +122,42 @@ describe("check if countTickets calculate fields correctly", () => {
     const count = countTickets(data as any);
     expect(count).toStrictEqual(expectedResult);
   });
+
+  it("should calculate the 'calculado' fields with 0 values", async () => {
+    const data = [
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "atendimento__iniciado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "atendimento__iniciado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status_acolhimento: "encaminhamento__realizado",
+        status: "closed",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 377501500792,
+        status: "closed",
+        status_acolhimento: "encaminhamento__realizado",
+        organization_id: 360282119532
+      }
+    ];
+
+    const expectedResult = {
+      atendimentos_em_andamento_calculado_: 0,
+      atendimentos_concludos_calculado_: 0,
+      encaminhamentos_realizados_calculado_: 0
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const count = countTickets(data as any);
+    expect(count).toStrictEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
If user only has closed/deleted/solved tickets, we didnt add a value to the `calculado` fields, so they remained null.

This was a problem because in the search for nearby volunteers, we filter them with `atendimentos_iniciados_calculados` = 0.

Some available volunteers weren't appearing in the results because of this. 