### PR TITLE
Fetches phone/whatsapp from form entry fields

### DIFF
--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -248,28 +248,28 @@ describe("filterByEmail", () => {
   ];
   describe("there's an entry with that e-mail", () => {
     it("should return an object with email/name/lastname/cep, part. 3", () => {
-      const data = filterByEmail(entries, "herminia.amorim@email.com");
+      const data = filterByEmail(entries);
       expect(data).toHaveProperty("email", "herminia.amorim@email.com");
       expect(data).toHaveProperty("cep", "22461010");
       expect(data).toHaveProperty("lastname", "Amorim");
       expect(data).toHaveProperty("name", "Hermínia");
     });
     it("should return an object with email/name/lastname/cep, part. 4", () => {
-      const data = filterByEmail(entries, "ligia.garcia@email.com");
+      const data = filterByEmail(entries);
       expect(data).toHaveProperty("email", "ligia.garcia@email.com");
       expect(data).toHaveProperty("cep", "61760-906");
       expect(data).toHaveProperty("lastname", "Garcia");
       expect(data).toHaveProperty("name", "Lígia");
     });
     it("should return an object with email/name/lastname/cep, part. 2", () => {
-      const data = filterByEmail(entries, "teresa.nascimento@email.com");
+      const data = filterByEmail(entries);
       expect(data).toHaveProperty("email", "teresa.nascimento@email.com");
       expect(data).toHaveProperty("cep", "82300332");
       expect(data).toHaveProperty("lastname", "Nascimento");
       expect(data).toHaveProperty("name", "Teresa");
     });
     it("should return an object with email/name/lastname/cep, part. 1", () => {
-      const data = filterByEmail(entries, "angelica.lopes@email.com");
+      const data = filterByEmail(entries);
       expect(data).toHaveProperty("email", "angelica.lopes@email.com");
       expect(data).toHaveProperty("cep", "05422030");
       expect(data).toHaveProperty("lastname", "Lopes");
@@ -278,24 +278,16 @@ describe("filterByEmail", () => {
   });
   describe("there's no entry with that e-mail", () => {
     it("should return undefined, part. 1", () => {
-      expect(filterByEmail(entries, "nossas@email.com")).toStrictEqual(
-        undefined
-      );
+      expect(filterByEmail(entries)).toStrictEqual(undefined);
     });
     it("should return undefined, part. 2", () => {
-      expect(filterByEmail(entries, "bonde@email.com")).toStrictEqual(
-        undefined
-      );
+      expect(filterByEmail(entries)).toStrictEqual(undefined);
     });
     it("should return undefined, part. 3", () => {
-      expect(filterByEmail(entries, "teste@email.com")).toStrictEqual(
-        undefined
-      );
+      expect(filterByEmail(entries)).toStrictEqual(undefined);
     });
     it("should return undefined, part. 4", () => {
-      expect(filterByEmail(entries, "ligia.garci@email.com")).toStrictEqual(
-        undefined
-      );
+      expect(filterByEmail(entries)).toStrictEqual(undefined);
     });
   });
 });

--- a/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
+++ b/packages/webhooks-mautic-zendesk/src/__tests__/utils.spec.ts
@@ -248,28 +248,28 @@ describe("filterByEmail", () => {
   ];
   describe("there's an entry with that e-mail", () => {
     it("should return an object with email/name/lastname/cep, part. 3", () => {
-      const data = filterByEmail(entries);
+      const data = filterByEmail([entries[0]]);
       expect(data).toHaveProperty("email", "herminia.amorim@email.com");
       expect(data).toHaveProperty("cep", "22461010");
       expect(data).toHaveProperty("lastname", "Amorim");
       expect(data).toHaveProperty("name", "Hermínia");
     });
     it("should return an object with email/name/lastname/cep, part. 4", () => {
-      const data = filterByEmail(entries);
+      const data = filterByEmail([entries[1]]);
       expect(data).toHaveProperty("email", "ligia.garcia@email.com");
       expect(data).toHaveProperty("cep", "61760-906");
       expect(data).toHaveProperty("lastname", "Garcia");
       expect(data).toHaveProperty("name", "Lígia");
     });
     it("should return an object with email/name/lastname/cep, part. 2", () => {
-      const data = filterByEmail(entries);
+      const data = filterByEmail([entries[2]]);
       expect(data).toHaveProperty("email", "teresa.nascimento@email.com");
       expect(data).toHaveProperty("cep", "82300332");
       expect(data).toHaveProperty("lastname", "Nascimento");
       expect(data).toHaveProperty("name", "Teresa");
     });
     it("should return an object with email/name/lastname/cep, part. 1", () => {
-      const data = filterByEmail(entries);
+      const data = filterByEmail([entries[3]]);
       expect(data).toHaveProperty("email", "angelica.lopes@email.com");
       expect(data).toHaveProperty("cep", "05422030");
       expect(data).toHaveProperty("lastname", "Lopes");
@@ -278,16 +278,7 @@ describe("filterByEmail", () => {
   });
   describe("there's no entry with that e-mail", () => {
     it("should return undefined, part. 1", () => {
-      expect(filterByEmail(entries)).toStrictEqual(undefined);
-    });
-    it("should return undefined, part. 2", () => {
-      expect(filterByEmail(entries)).toStrictEqual(undefined);
-    });
-    it("should return undefined, part. 3", () => {
-      expect(filterByEmail(entries)).toStrictEqual(undefined);
-    });
-    it("should return undefined, part. 4", () => {
-      expect(filterByEmail(entries)).toStrictEqual(undefined);
+      expect(filterByEmail([])).toStrictEqual(undefined);
     });
   });
 });

--- a/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/AdvogadaCreateUser.ts
@@ -15,6 +15,8 @@ interface InputFromMautic {
   name: string;
   cep?: string;
   registration_number: string | null;
+  phone: string | null;
+  whatsapp: string | null;
 }
 
 class AdvogadaCreateUser extends Base {
@@ -28,7 +30,14 @@ class AdvogadaCreateUser extends Base {
 
   start = async (
     data,
-    { createdAt, name, cep, registration_number }: InputFromMautic
+    {
+      createdAt,
+      name,
+      cep,
+      registration_number,
+      phone,
+      whatsapp
+    }: InputFromMautic
   ) => {
     let newData = {
       ...data,
@@ -55,7 +64,7 @@ class AdvogadaCreateUser extends Base {
         .transform(obj => {
           const {
             email,
-            phone,
+            phone: mauticPhone,
             latitude,
             longitude,
             address,
@@ -70,12 +79,13 @@ class AdvogadaCreateUser extends Base {
           return {
             name,
             email,
-            phone,
+            phone: mauticPhone || phone,
             organization_id: this.organizations[this.organization],
             user_fields: {
               ...removeFalsyValues(userFields),
               registration_number:
                 userFields.registration_number || registration_number,
+              whatsapp: userFields.whatsapp || whatsapp,
               cep,
               address,
               state,

--- a/packages/webhooks-mautic-zendesk/src/integrations/BondeCreatedDate.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/BondeCreatedDate.ts
@@ -50,8 +50,8 @@ class BondeCreatedDate {
           stripUnknown: true
         }
       );
-      const filteredFormEntry = filterByEmail(validatedFormEntries, this.email);
-      if (!filteredFormEntry) {
+      const parsedFieldsFormEntry = filterByEmail(validatedFormEntries);
+      if (!parsedFieldsFormEntry) {
         throw new Error(`formEntries not found for email ${this.email}`);
       }
       const {
@@ -59,8 +59,10 @@ class BondeCreatedDate {
         lastname,
         cep,
         created_at: createdAt,
-        registration_number
-      } = filteredFormEntry;
+        registration_number,
+        whatsapp,
+        phone
+      } = parsedFieldsFormEntry;
       const aux = {
         createdAt,
         name:
@@ -71,7 +73,9 @@ class BondeCreatedDate {
           typeof this.cep !== "string" || this.cep?.length === 0
             ? String(cep)
             : this.cep,
-        registration_number
+        registration_number,
+        whatsapp,
+        phone
       };
       this.apm.setUserContext({
         username: aux.name
@@ -99,7 +103,9 @@ class BondeCreatedDate {
         createdAt: new Date().toISOString(),
         name: this.name || "sem nome",
         cep: this.cep ?? undefined,
-        registration_number: null
+        registration_number: null,
+        whatsapp: null,
+        phone: null
       };
     }
   };

--- a/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
+++ b/packages/webhooks-mautic-zendesk/src/integrations/PsicologaCreateUser.ts
@@ -15,6 +15,8 @@ interface InputFromMautic {
   name: string;
   cep?: string;
   registration_number: string | null;
+  phone: string | null;
+  whatsapp: string | null;
 }
 
 class PsicologaCreateUser extends Base {
@@ -28,7 +30,14 @@ class PsicologaCreateUser extends Base {
 
   start = async (
     data,
-    { createdAt, name, cep, registration_number }: InputFromMautic
+    {
+      createdAt,
+      name,
+      cep,
+      registration_number,
+      phone,
+      whatsapp
+    }: InputFromMautic
   ) => {
     let newData = {
       ...data,
@@ -55,7 +64,7 @@ class PsicologaCreateUser extends Base {
         .transform(obj => {
           const {
             email,
-            phone,
+            phone: mauticPhone,
             latitude,
             longitude,
             address,
@@ -70,12 +79,13 @@ class PsicologaCreateUser extends Base {
           return {
             name,
             email,
-            phone,
+            phone: mauticPhone || phone,
             organization_id: this.organizations[this.organization],
             user_fields: {
               ...removeFalsyValues(userFields),
               registration_number:
                 userFields.registration_number || registration_number,
+              whatsapp: userFields.whatsapp || whatsapp,
               cep,
               address,
               state,

--- a/packages/webhooks-mautic-zendesk/src/utils.ts
+++ b/packages/webhooks-mautic-zendesk/src/utils.ts
@@ -165,8 +165,7 @@ export const checkCep = (cep?: string) => {
 };
 
 export const filterByEmail = (
-  formEntries: FormEntry[],
-  email: string
+  formEntries: FormEntry[]
 ):
   | {
       name: string | null;
@@ -175,6 +174,8 @@ export const filterByEmail = (
       created_at: string;
       widget_id: number;
       registration_number: string;
+      whatsapp: string | null;
+      phone: string;
     }
   | undefined => {
   const dicio = {
@@ -201,25 +202,39 @@ export const filterByEmail = (
     "field-1530889245511-83": "registration_number",
     "field-1530889844695-35": "registration_number",
     "field-1533733501716-34": "registration_number",
-    "field-1533735761357-93": "registration_number"
+    "field-1533735761357-93": "registration_number",
+    "field-1464961993261-67": "phone",
+    "field-1530889321904-94": "phone",
+    "field-1533734419113-13": "phone",
+    "field-1497369273804-61": "phone",
+    "field-1530889910384-28": "phone",
+    "field-1533735813563-2": "phone",
+    "field-1465303586925-83": "whatsapp",
+    "field-1530889345052-73": "whatsapp",
+    "field-1533734468460-38": "whatsapp",
+    "field-1530889937136-21": "whatsapp",
+    "field-1533735832329-53": "whatsapp",
+    "field-1593720184872-74": "whatsapp",
+    "field-1593717629660-4": "whatsapp"
   };
   const getFieldsValue = formEntries.map(i => {
     try {
       const parsedFields = JSON.parse(i.fields);
+      const translateFieldsIntoObject = parsedFields.reduce((newObj, old) => {
+        const key = (dicio[old.uid] && dicio[old.uid]) || old.kind;
+        return {
+          ...newObj,
+          [key]: old.value
+        };
+      }, {});
       return {
         ...i,
-        ...parsedFields.reduce((newObj, old) => {
-          const key = (dicio[old.uid] && dicio[old.uid]) || old.kind;
-          return {
-            ...newObj,
-            [key]: old.value
-          };
-        }, {})
+        ...translateFieldsIntoObject
       };
     } catch (e) {
       console.log(e);
-      return undefined;
+      return [];
     }
   });
-  return getFieldsValue.find(f => f.email === email);
+  return getFieldsValue[0];
 };


### PR DESCRIPTION
Before we didnt fetch phone and whatsapp from the form_entry fields.
Now we do because it appeared that many volunteers with pratically all
correct data weren't appearing as a match possibility because they
lacked phone/whatsapp number.

Now we fetch that data as well before saving the user to zendesk.

We also don't filter volunteers by the exact same email put into
Zendesk/mautic, we stick with the similarity between the emails that the hasura query returned.
Considering some users just misspelled somethings and then they remained with
no lat/lng, by removing the search for the exact same email prevents
that.