### PR TITLE
fix: add service tags to zendesk ticket count

### DIFF
--- a/packages/cli-zendesk/src/__tests__/countTickets.spec.ts
+++ b/packages/cli-zendesk/src/__tests__/countTickets.spec.ts
@@ -17,6 +17,30 @@ describe("check if countTickets calculate fields correctly", () => {
       },
       {
         requester_id: 396650460752,
+        status_acolhimento: "atendimento_triagem_1",
+        status: "pending",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 396650460752,
+        status_acolhimento: "atendimento_triagem_2",
+        status: "pending",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 396650460752,
+        status_acolhimento: "atendimento_acompanhamento_1",
+        status: "pending",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 396650460752,
+        status_acolhimento: "atendimento_acompanhamento_2",
+        status: "pending",
+        organization_id: 360282119532
+      },
+      {
+        requester_id: 396650460752,
         status_acolhimento: "encaminhamento__negado",
         status: "solved",
         organization_id: 360282119532
@@ -43,7 +67,7 @@ describe("check if countTickets calculate fields correctly", () => {
     const expectedResult = {
       "396650460752": {
         id: 396650460752,
-        atendimentos_em_andamento_calculado_: 1,
+        atendimentos_em_andamento_calculado_: 5,
         atendimentos_concludos_calculado_: 0,
         encaminhamentos_realizados_calculado_: 1
       },

--- a/packages/cli-zendesk/src/countTickets.ts
+++ b/packages/cli-zendesk/src/countTickets.ts
@@ -4,7 +4,7 @@ import { Ticket } from "./interfaces/Ticket";
 // import updateTicketRelation from "./updateTicketRelation";
 
 /*
-  Initiates a requester entry if none was already initiated, then adds to their calculated fields accordingly. 
+  Initiates a requester entry if none was already initiated, then adds to their calculated fields accordingly.
   Each ticket has a requester, but the fields "calculado" are in the user fields. That's why we need to initiate the requesters object, and add to the "calculado" field according to the requester_id.
 */
 const countTickets = async (tickets: Ticket[]): Promise<Requesters> => {
@@ -30,9 +30,20 @@ const countTickets = async (tickets: Ticket[]): Promise<Requesters> => {
       i.status !== "solved" &&
       i.status !== "closed"
     ) {
-      // Atualiza os atendimentos em andamento:
       switch (i.status_acolhimento) {
         case "atendimento__iniciado":
+          requester.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_triagem_1":
+          requester.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_triagem_2":
+          requester.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_acompanhamento_1":
+          requester.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_acompanhamento_2":
           requester.atendimentos_em_andamento_calculado_ += 1;
           break;
         case "atendimento__concluído":

--- a/packages/cli-zendesk/src/interfaces/Ticket.ts
+++ b/packages/cli-zendesk/src/interfaces/Ticket.ts
@@ -27,6 +27,10 @@ export const dicio: {
 type status_acolhimento_values =
   | "atendimento__concluído"
   | "atendimento__iniciado"
+  | "atendimento_triagem_1"
+  | "atendimento_triagem_2"
+  | "atendimento_acompanhamento_1"
+  | "atendimento_acompanhamento_2"
   | "atendimento__interrompido"
   | "encaminhamento__aguardando_confirmação"
   | "encaminhamento__confirmou_disponibilidade"

--- a/packages/listener-solidarity/src/types/index.ts
+++ b/packages/listener-solidarity/src/types/index.ts
@@ -207,15 +207,3 @@ export type CustomFields = {
   cidade?: null;
   atrelado_ao_ticket?: string | null;
 };
-
-export type status_acolhimento_values =
-  | "atendimento__concluído"
-  | "atendimento__iniciado"
-  | "atendimento__interrompido"
-  | "encaminhamento__aguardando_confirmação"
-  | "encaminhamento__confirmou_disponibilidade"
-  | "encaminhamento__negado"
-  | "encaminhamento__realizado"
-  | "encaminhamento__realizado_para_serviço_público"
-  | "solicitação_recebida"
-  | "solicitação_repetida";

--- a/packages/webhooks-solidarity-count/src/__tests__/countTicket.spec.ts
+++ b/packages/webhooks-solidarity-count/src/__tests__/countTicket.spec.ts
@@ -8,6 +8,10 @@ describe("check if countTickets calculate fields correctly", () => {
         status: "pending"
       },
       {
+        status_acolhimento: "atendimento_triagem_2",
+        status: "pending"
+      },
+      {
         status_acolhimento: "atendimento__iniciado",
         status: "pending"
       },
@@ -29,7 +33,7 @@ describe("check if countTickets calculate fields correctly", () => {
       }
     ];
     const expectedResult = {
-      atendimentos_em_andamento_calculado_: 1,
+      atendimentos_em_andamento_calculado_: 2,
       atendimentos_concludos_calculado_: 0,
       encaminhamentos_realizados_calculado_: 3
     };

--- a/packages/webhooks-solidarity-count/src/countTickets.ts
+++ b/packages/webhooks-solidarity-count/src/countTickets.ts
@@ -17,11 +17,23 @@ const countTickets = (tickets: Array<TicketZendesk & customFields>) => {
         case "atendimento__iniciado":
           userCount.atendimentos_em_andamento_calculado_ += 1;
           break;
-        case "atendimento__concluído":
-          userCount.atendimentos_concludos_calculado_ += 1;
+        case "atendimento_triagem_1":
+          userCount.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_triagem_2":
+          userCount.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_acompanhamento_1":
+          userCount.atendimentos_em_andamento_calculado_ += 1;
+          break;
+        case "atendimento_acompanhamento_2":
+          userCount.atendimentos_em_andamento_calculado_ += 1;
           break;
         case "encaminhamento__realizado":
           userCount.encaminhamentos_realizados_calculado_ += 1;
+          break;
+        case "atendimento__concluído":
+          userCount.atendimentos_concludos_calculado_ += 1;
           break;
         default:
           return false;

--- a/packages/webhooks-solidarity-count/src/interfaces/Ticket/index.ts
+++ b/packages/webhooks-solidarity-count/src/interfaces/Ticket/index.ts
@@ -3,6 +3,10 @@ import dicio from "./dicio";
 export type status_acolhimento_values =
   | "atendimento__concluído"
   | "atendimento__iniciado"
+  | "atendimento_triagem_1"
+  | "atendimento_triagem_2"
+  | "atendimento_acompanhamento_1"
+  | "atendimento_acompanhamento_2"
   | "atendimento__interrompido"
   | "encaminhamento__aguardando_confirmação"
   | "encaminhamento__confirmou_disponibilidade"


### PR DESCRIPTION
- [x]  Adiciona atendimento_triagem_1", "atendimento_triagem_2", "atendimento_acompanhamento_1" e atendimento_acompanhamento_2" à contagem de atendimentos em andamentos do Zendesk