### PR TITLE
[MAPA-61] fix(solidarity): filters valid tickets if they have open and new status

### DIFF
--- a/packages/listener-solidarity/src/components/SupportRequest/__tests__/index.spec.ts
+++ b/packages/listener-solidarity/src/components/SupportRequest/__tests__/index.spec.ts
@@ -7,37 +7,39 @@ jest.mock("jsonwebtoken");
 
 describe("createSupportRequests", () => {
   it("should throw an error if there are only 'undefined' tickets", async () => {
-    await expect(createSupportRequests([undefined], [])).rejects.toThrow(
+    const invalidTickets = await createSupportRequests([undefined], []);
+    expect(invalidTickets).toStrictEqual(
       "No valid tickets to save as support requests"
     );
   });
   it("should throw an error if there are no 'open' tickets", async () => {
-    await expect(
-      createSupportRequests(
-        [{ requester_id: 1, id: 1, status: "closed" }] as Ticket[],
-        [{ user_id: 1 }] as User[]
-      )
-    ).rejects.toThrow("No valid tickets to save as support requests");
+    const invalidTickets = await createSupportRequests(
+      [{ requester_id: 1, id: 1, status: "closed" }] as Ticket[],
+      [{ user_id: 1 }] as User[]
+    );
+    expect(invalidTickets).toStrictEqual(
+      "No valid tickets to save as support requests"
+    );
   });
   it("should return error res when no user is found for the ticket", async () => {
-    expect(
-      await createSupportRequests(
+    await expect(
+      createSupportRequests(
         [{ requester_id: 1, id: 1, status: "open" }] as Ticket[],
         [{ user_id: 2 }, { user_id: 3 }] as User[]
       )
-    ).toStrictEqual(
+    ).rejects.toThrow(
       "Couldnt create support requests for these tickets: 1 and got this error: Didn't find a user for this ticket"
     );
   });
   it("should return error res when ticket has unsupported support type", async () => {
-    expect(
-      await createSupportRequests(
+    await expect(
+      createSupportRequests(
         [
           { requester_id: 1, id: 1, subject: "foo bar", status: "open" },
         ] as Ticket[],
         [{ user_id: 1 }] as User[]
       )
-    ).toStrictEqual(
+    ).rejects.toThrow(
       "Couldnt create support requests for these tickets: 1 and got this error: Unsupported support type"
     );
   });
@@ -48,8 +50,8 @@ describe("createSupportRequests", () => {
         data: "foo bar",
       },
     });
-    expect(
-      await createSupportRequests(
+    await expect(
+      createSupportRequests(
         [
           {
             id: 1,
@@ -68,7 +70,7 @@ describe("createSupportRequests", () => {
           },
         ] as User[]
       )
-    ).toStrictEqual(
+    ).rejects.toThrow(
       'Couldnt create support requests for these tickets: 1 and got this error: 400 - "foo bar"'
     );
   });

--- a/packages/listener-solidarity/src/components/SupportRequest/index.ts
+++ b/packages/listener-solidarity/src/components/SupportRequest/index.ts
@@ -23,7 +23,7 @@ export default async function createSupportRequests(
 ) {
   const validTickets = (msrZendeskTickets || [])
     .filter(Boolean)
-    .filter((ticket) => ticket?.status === "open");
+    .filter((ticket) => ticket?.status === "open" || ticket?.status === "new");
   if (validTickets.length < 1)
     throw new Error("No valid tickets to save as support requests");
   const ticketIds = validTickets.map((ticket) => (ticket ? ticket.id : ""));

--- a/packages/listener-solidarity/src/components/SupportRequest/index.ts
+++ b/packages/listener-solidarity/src/components/SupportRequest/index.ts
@@ -24,8 +24,10 @@ export default async function createSupportRequests(
   const validTickets = (msrZendeskTickets || [])
     .filter(Boolean)
     .filter((ticket) => ticket?.status === "open" || ticket?.status === "new");
+
   if (validTickets.length < 1)
-    throw new Error("No valid tickets to save as support requests");
+    return "No valid tickets to save as support requests";
+
   const ticketIds = validTickets.map((ticket) => (ticket ? ticket.id : ""));
 
   try {
@@ -58,13 +60,13 @@ export default async function createSupportRequests(
         axiosError?.response?.status
       } - ${JSON.stringify(axiosError?.response?.data)}`;
       log.error(axiosErrorMsg);
-      return axiosErrorMsg;
+      throw new Error(axiosErrorMsg);
     }
 
     const error = e as Error;
     const errorMsg = `Couldnt create support requests for these tickets: ${ticketIds} and got this error: ${error.message}`;
     log.error(errorMsg);
 
-    return errorMsg;
+    throw new Error(errorMsg);
   }
 }

--- a/packages/listener-solidarity/src/components/index.ts
+++ b/packages/listener-solidarity/src/components/index.ts
@@ -118,7 +118,9 @@ export const handleIntegration = (widgets: Widget[], apm) => async (
     );
 
     // Creates support requests on lambda-pedido-acolhimento
-    createSupportRequests(zendeskTickets, msrUsers);
+    createSupportRequests(zendeskTickets, msrUsers).catch((e) => {
+      log.error(`Couldn't createSupportRequests: ${e.message}`);
+    });
 
     // Save users in Hasura
     insertSolidarityUsers(withoutDuplicates as never).catch(e => {


### PR DESCRIPTION
No valid tickets were being found because after creating a ticket in Zendesk it returns as 'new', not 'open'. This check is done because some tickets are 'solicitacao-repetida' and automatically have a 'pending' status, or they could be an invalid support request, so they are automatically 'closed'.