### PR TITLE
[MAPA-69] fix(solidarity): removes external_id if stg before saving in zendesk

### DIFF
--- a/packages/listener-solidarity/src/components/User/createZendeskUsers.ts
+++ b/packages/listener-solidarity/src/components/User/createZendeskUsers.ts
@@ -1,6 +1,7 @@
 import client from "../../zendesk";
 import { User, ZendeskUserCreationResponse } from "../../types";
 import logger from "../../logger";
+import { isProduction } from "../../utils";
 
 const log = logger.child({ labels: { process: "createZendeskUsers" } });
 
@@ -8,33 +9,44 @@ export default async (
   users: User[]
 ): Promise<ZendeskUserCreationResponse[] | undefined> => {
   log.info(`Entering createZendeskUser`);
-  // ADD YUP VALIDATION
-  return new Promise(resolve => {
-    return client.users.createOrUpdateMany({ users }, (err, _req, result) => {
-      if (err) {
-        log.error(err);
-        return resolve(undefined);
-      }
-      return client.jobstatuses.watch(
-        (result as { job_status: { id: number } })["job_status"].id,
-        5000,
-        0,
-        (err, _req, result) => {
-          if (err) {
-            log.error(err);
-            return resolve(undefined);
-          }
-          const results = result as { job_status: { status: string; results } };
 
-          if (
-            results &&
-            results["job_status"] &&
-            results["job_status"]["status"] === "completed"
-          ) {
-            return resolve(results["job_status"]["results"]);
-          }
+  let zendeskUsers = users;
+  const shouldRemoveExternalId = !isProduction();
+  if (shouldRemoveExternalId) {
+    zendeskUsers = users.map(({ external_id: _, ...user }) => user);
+  }
+
+  return new Promise(resolve => {
+    return client.users.createOrUpdateMany(
+      { users: zendeskUsers },
+      (err, _req, result) => {
+        if (err) {
+          log.error(err);
+          return resolve(undefined);
         }
-      );
-    });
+        return client.jobstatuses.watch(
+          (result as { job_status: { id: number } })["job_status"].id,
+          5000,
+          0,
+          (err, _req, result) => {
+            if (err) {
+              log.error(err);
+              return resolve(undefined);
+            }
+            const results = result as {
+              job_status: { status: string; results };
+            };
+
+            if (
+              results &&
+              results["job_status"] &&
+              results["job_status"]["status"] === "completed"
+            ) {
+              return resolve(results["job_status"]["results"]);
+            }
+          }
+        );
+      }
+    );
   });
 };

--- a/packages/listener-solidarity/src/components/index.ts
+++ b/packages/listener-solidarity/src/components/index.ts
@@ -97,7 +97,9 @@ export const handleIntegration = (widgets: Widget[], apm) => async (
     const hasuraUsers = userBatches
       .filter(r => !(r.error && r.error.match(/permissiondenied/i)))
       .map(r => {
-        const user = usersToRegister.find(u => u.external_id === r.external_id);
+        const user = usersToRegister.find(
+          (u) => u.email === r.email || u.external_id === r.external_id
+        );
         return {
           ...user,
           ...((user && user.user_fields) || {}),

--- a/packages/listener-solidarity/src/types/index.ts
+++ b/packages/listener-solidarity/src/types/index.ts
@@ -196,7 +196,8 @@ export type Fields = Array<{
 export type ZendeskUserCreationResponse = {
   id: number;
   status: string;
-  external_id: string;
+  external_id?: string;
+  email: string;
   error?: string | undefined;
 };
 

--- a/packages/listener-solidarity/src/types/index.ts
+++ b/packages/listener-solidarity/src/types/index.ts
@@ -30,7 +30,7 @@ export type User = {
   organization_id: number;
   name: string;
   email: string;
-  external_id: string;
+  external_id?: string;
   phone: string;
   user_id?: number;
   verified: boolean;

--- a/packages/listener-solidarity/src/utils/index.ts
+++ b/packages/listener-solidarity/src/utils/index.ts
@@ -105,3 +105,5 @@ export const getStatusAcolhimento = (
 };
 
 export { default as getSupportRequests } from "./getSupportRequests";
+
+export const isProduction = () => process.env.NODE_ENV === "production";


### PR DESCRIPTION
Descobrimos um bug que estava acontecendo ao fazermos os testes do novo match em STG.

Os external_ids de entradas de forms em STG estavam, algumas vezes, sendo iguais aos de PROD. O que levava, ao criarmos a usuária no Zendesk, a atualizar a pessoa errada. 

Nesse fix eu não mando external_id para o zendesk caso estivermos em STG